### PR TITLE
Catch zero-arg and unused-overrides test fixtures

### DIFF
--- a/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
+++ b/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
@@ -101,6 +101,45 @@ tester.run('no-module-scope-test-setup', rule, {
       name: 'object literal inside arrow function at describe scope',
       code: `describe('suite', () => { const build = () => { const data = { name: 'test' }; return data; }; });`,
     },
+    // zero-arg factory that is never called from test code — no CallExpression usage
+    {
+      name: 'zero-arg arrow returning an object, never called',
+      code: `describe('suite', () => { const buildData = () => { return { name: 'test' }; }; });`,
+    },
+    // factory takes a real parameter — not a zero-arg fixture
+    {
+      name: 'arrow factory with a parameter',
+      code: `describe('suite', () => { const buildProps = (name) => ({ name }); it('renders', () => { render(buildProps('a')); }); });`,
+    },
+    // overrides parameter genuinely used at a call site in the same scope
+    {
+      name: 'overrides factory used with arguments in the same describe',
+      code: `describe('suite', () => { const buildProps = (overrides = {}) => ({ name: 'a', ...overrides }); it('renders', () => { render(buildProps({ name: 'b' })); }); });`,
+    },
+    // overrides factory has a mix of zero-arg and with-arg call sites — real usage exists
+    {
+      name: 'overrides factory with mixed call sites in the same describe',
+      code: `describe('suite', () => { const buildProps = (overrides = {}) => ({ name: 'a', ...overrides }); it('default', () => { render(buildProps()); }); it('custom', () => { render(buildProps({ name: 'b' })); }); });`,
+    },
+    // overrides factory never called at all — not our concern (unused-vars territory)
+    {
+      name: 'overrides factory declared but never called',
+      code: `describe('suite', () => { const buildProps = (overrides = {}) => ({ name: 'a', ...overrides }); });`,
+    },
+    // same factory name in a sibling describe DOES pass overrides — must not affect this scope
+    {
+      name: 'overrides used in a sibling describe with the same factory name',
+      code: `describe('outer', () => {
+        describe('a', () => {
+          const buildProps = (overrides = {}) => ({ name: 'a', ...overrides });
+          it('uses overrides', () => { render(buildProps({ name: 'custom' })); });
+        });
+        describe('b', () => {
+          const buildProps = (overrides = {}) => ({ name: 'a', ...overrides });
+          it('no overrides here either, but different scope', () => { render(buildProps({ x: 1 })); });
+        });
+      });`,
+    },
   ],
 
   invalid: [
@@ -177,6 +216,58 @@ tester.run('no-module-scope-test-setup', rule, {
       name: 'wrapper helper function at top-level describe scope',
       code: `describe('suite', () => { function buildTestWrapper(req) { return buildWrapper([getBaseProviderWrapper()]); } });`,
       errors: [{ messageId: 'noModuleScopeWrapperHelper', data: { name: 'buildTestWrapper' } }],
+    },
+
+    // zero-arg fixture: arrow function const, called from a test
+    {
+      name: 'zero-arg arrow returning an object literal, called from a test',
+      code: `describe('suite', () => { const buildProps = () => ({ name: 'test' }); it('renders', () => { render(buildProps()); }); });`,
+      errors: [{ messageId: 'noZeroArgFixture', data: { name: 'buildProps' } }],
+    },
+    // zero-arg fixture: function declaration at module scope
+    {
+      name: 'zero-arg function declaration returning an object, called from a test',
+      code: `function buildProps() { return { name: 'test' }; } it('renders', () => { render(buildProps()); });`,
+      errors: [{ messageId: 'noZeroArgFixture', data: { name: 'buildProps' } }],
+    },
+    // zero-arg fixture: return value is a build*/create* call rather than a literal
+    {
+      name: 'zero-arg function returning a factory-like call, called from a test',
+      code: `function buildRequest() { return createQueryMockRouter({ GetThing: {} }); } it('renders', () => { render(buildRequest()); });`,
+      errors: [{ messageId: 'noZeroArgFixture', data: { name: 'buildRequest' } }],
+    },
+    // zero-arg fixture: nested describe scope (not just the outermost describe)
+    {
+      name: 'zero-arg arrow at nested describe scope, called from a test',
+      code: `describe('outer', () => { describe('inner', () => { const buildProps = () => ({ name: 'test' }); it('renders', () => { render(buildProps()); }); }); });`,
+      errors: [{ messageId: 'noZeroArgFixture', data: { name: 'buildProps' } }],
+    },
+    // unused-overrides fixture: only call site in scope passes no arguments
+    {
+      name: 'overrides factory with a single zero-arg call site in the same describe',
+      code: `describe('suite', () => { const buildProps = (overrides = {}) => ({ name: 'test', ...overrides }); it('renders', () => { render(buildProps()); }); });`,
+      errors: [{ messageId: 'noUnusedOverridesFixture', data: { name: 'buildProps' } }],
+    },
+    // unused-overrides fixture: all call sites in scope pass no arguments (multiple tests)
+    {
+      name: 'overrides factory with multiple zero-arg call sites in the same describe',
+      code: `describe('suite', () => { const buildProps = (overrides = {}) => ({ name: 'test', ...overrides }); it('a', () => { render(buildProps()); }); it('b', () => { render(buildProps()); }); });`,
+      errors: [{ messageId: 'noUnusedOverridesFixture', data: { name: 'buildProps' } }],
+    },
+    // unused-overrides fixture: same name defined twice, only the unused copy is flagged
+    {
+      name: 'same factory name in two describes — only the unused-overrides copy is flagged',
+      code: `describe('outer', () => {
+        describe('unused', () => {
+          const buildProps = (overrides = {}) => ({ name: 'a', ...overrides });
+          it('never passes overrides', () => { render(buildProps()); });
+        });
+        describe('used', () => {
+          const buildProps = (overrides = {}) => ({ name: 'a', ...overrides });
+          it('passes overrides', () => { render(buildProps({ name: 'custom' })); });
+        });
+      });`,
+      errors: [{ messageId: 'noUnusedOverridesFixture', data: { name: 'buildProps' } }],
     },
   ],
 });

--- a/javascript/eslint-local-rules/no-module-scope-test-setup.js
+++ b/javascript/eslint-local-rules/no-module-scope-test-setup.js
@@ -25,6 +25,12 @@ const rule = {
 
       noModuleScopeSetupConst:
         "'{{ name }}' is declared at module scope but looks like test setup (props, options, config). Inline it inside each test, or group shared setup in a nested describe with a factory function.",
+
+      noZeroArgFixture:
+        "'{{ name }}' takes no parameters — it's a constant as a function. Inline the literal in each test, or move it to beforeEach.",
+
+      noUnusedOverridesFixture:
+        "'{{ name }}' accepts overrides but no call site in this scope passes any. Drop the parameter and inline the literal, or add meaningful overrides.",
     },
     schema: [],
   },
@@ -142,52 +148,279 @@ const rule = {
       );
     }
 
+    /**
+     * True for calls like `createQueryMockRouter({ ... })` — a build-/create-prefixed
+     * helper invoked with an object/array literal, the shape of a fixture-producing call.
+     */
+    function isFactoryLikeCall(node) {
+      if (!node || node.type !== 'CallExpression') return false;
+      const { callee } = node;
+      if (callee.type !== 'Identifier' || !/^(build|create)/.test(callee.name)) return false;
+      return node.arguments.some(
+        (arg) => arg.type === 'ObjectExpression' || arg.type === 'ArrayExpression'
+      );
+    }
+
+    function returnValueLooksLikeFixture(value) {
+      return looksLikeSetupData(value) || isFactoryLikeCall(value);
+    }
+
+    /** Walks return statements (including simple if/else branches) collecting their arguments. */
+    function collectReturnArguments(node, results) {
+      if (!node) return;
+      if (node.type === 'ReturnStatement') {
+        results.push(node.argument);
+        return;
+      }
+      if (node.type === 'BlockStatement') {
+        for (const stmt of node.body) collectReturnArguments(stmt, results);
+        return;
+      }
+      if (node.type === 'IfStatement') {
+        collectReturnArguments(node.consequent, results);
+        collectReturnArguments(node.alternate, results);
+      }
+    }
+
+    /**
+     * Does this function, given zero arguments, produce fixture-like data? Checks the
+     * expression body of a concise arrow, or every return statement of a block body.
+     */
+    function functionReturnsFixtureLikeValue(fn) {
+      if (fn.body.type !== 'BlockStatement') {
+        return returnValueLooksLikeFixture(fn.body);
+      }
+      const returnArgs = [];
+      collectReturnArguments(fn.body, returnArgs);
+      return returnArgs.some(returnValueLooksLikeFixture);
+    }
+
+    /**
+     * Like isModuleScope, but treats a describe() callback at ANY nesting depth as
+     * qualifying scope — not just the outermost. Used by the zero-arg-fixture and
+     * unused-overrides checks, which must catch factories hiding in nested describes.
+     */
+    function isDescribeOrModuleScope(node) {
+      let current = node.parent;
+      while (current) {
+        if (current.type === 'Program') return true;
+        if (
+          (current.type === 'FunctionDeclaration' ||
+            current.type === 'FunctionExpression' ||
+            current.type === 'ArrowFunctionExpression') &&
+          isStandaloneFunction(current)
+        ) {
+          return false;
+        }
+        if (current.type === 'CallExpression') {
+          const name = getCalleeName(current);
+          if (name && TEST_HOOKS.has(name)) return false;
+          if (name === 'describe') return true;
+        }
+        current = current.parent;
+      }
+      return true;
+    }
+
+    /**
+     * The nearest enclosing describe() call (or Program, if none) — used as a scope
+     * key so the unused-overrides and zero-arg checks compare a factory only against
+     * call sites that can actually reach its declaration, not the whole file.
+     */
+    function getNearestScopeContainer(node) {
+      let current = node.parent;
+      while (current) {
+        if (current.type === 'Program') return current;
+        if (current.type === 'CallExpression' && getCalleeName(current) === 'describe') {
+          return current;
+        }
+        current = current.parent;
+      }
+      return null;
+    }
+
+    /**
+     * True when `node` is lexically inside `scopeContainer` — i.e. a call site that
+     * could actually see a factory declared in that scope. Program contains everything.
+     * A describe() scope contains itself and any describe/test hook nested inside it,
+     * but not a sibling describe that happens to declare a same-named factory.
+     */
+    function isWithinScope(node, scopeContainer) {
+      if (!scopeContainer || scopeContainer.type === 'Program') return true;
+      let current = node;
+      while (current) {
+        if (current === scopeContainer) return true;
+        current = current.parent;
+      }
+      return false;
+    }
+
+    /** True for a single `(overrides = {})`-shaped parameter list. */
+    function isSingleOverridesParam(params) {
+      if (params.length !== 1) return false;
+      const [param] = params;
+      return (
+        param.type === 'AssignmentPattern' &&
+        param.right.type === 'ObjectExpression' &&
+        param.right.properties.length === 0
+      );
+    }
+
+    function isZeroArgFactory(fnNode) {
+      if (!fnNode) return false;
+      if (fnNode.type !== 'FunctionExpression' && fnNode.type !== 'ArrowFunctionExpression') {
+        return false;
+      }
+      return fnNode.params.length === 0 && functionReturnsFixtureLikeValue(fnNode);
+    }
+
+    function isOverridesOnlyFactory(fnNode) {
+      if (!fnNode) return false;
+      if (fnNode.type !== 'FunctionExpression' && fnNode.type !== 'ArrowFunctionExpression') {
+        return false;
+      }
+      return isSingleOverridesParam(fnNode.params) && functionReturnsFixtureLikeValue(fnNode);
+    }
+
+    // Factories declared with 0 params, or with a single unused `(overrides = {})` param,
+    // collected during the main traversal and checked against call sites in the same
+    // scope at Program:exit. A candidate is only a fixture if test code actually calls
+    // it — otherwise it may be a React component only ever used as JSX (e.g. `<Foo />`).
+    const zeroArgCandidates = [];
+    const overrideCandidates = [];
+    // Every call `foo(...)` in the file, with the scope it was found in.
+    const callSites = [];
+
     return {
       FunctionDeclaration(node) {
-        if (!isModuleScope(node)) return;
         const name = node.id?.name ?? '<anonymous>';
-        if (bodyCallsBuildWrapper(node.body)) {
+        const inModuleScope = isModuleScope(node);
+        const inDescribeScope = isDescribeOrModuleScope(node);
+
+        if (inModuleScope && bodyCallsBuildWrapper(node.body)) {
           context.report({
             node,
             messageId: 'noModuleScopeWrapperHelper',
             data: { name },
           });
+          return;
+        }
+
+        if (!inDescribeScope) return;
+
+        if (node.params.length === 0 && functionReturnsFixtureLikeValue(node)) {
+          zeroArgCandidates.push({
+            name,
+            reportNode: node,
+            scopeContainer: getNearestScopeContainer(node),
+          });
+          return;
+        }
+
+        if (isOverridesOnlyFactory(node)) {
+          overrideCandidates.push({
+            name,
+            reportNode: node,
+            scopeContainer: getNearestScopeContainer(node),
+          });
         }
       },
 
       VariableDeclaration(node) {
-        if (!isModuleScope(node)) return;
+        const inModuleScope = isModuleScope(node);
+        const inDescribeScope = isDescribeOrModuleScope(node);
+        if (!inModuleScope && !inDescribeScope) return;
 
         for (const declarator of node.declarations) {
           const { init, id } = declarator;
           const name = id.type === 'Identifier' ? id.name : '<destructured>';
 
-          if (callsBuildWrapper(init)) {
-            context.report({
-              node: declarator,
-              messageId: 'noModuleScopeWrapper',
+          if (inModuleScope) {
+            if (callsBuildWrapper(init)) {
+              context.report({
+                node: declarator,
+                messageId: 'noModuleScopeWrapper',
+              });
+              continue;
+            }
+
+            if (
+              init &&
+              (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') &&
+              bodyCallsBuildWrapper(init.body)
+            ) {
+              context.report({
+                node: declarator,
+                messageId: 'noModuleScopeWrapperHelper',
+                data: { name },
+              });
+              continue;
+            }
+
+            if (looksLikeSetupData(init)) {
+              context.report({
+                node: declarator,
+                messageId: 'noModuleScopeSetupConst',
+                data: { name },
+              });
+              continue;
+            }
+          }
+
+          if (!inDescribeScope) continue;
+
+          if (isZeroArgFactory(init)) {
+            zeroArgCandidates.push({
+              name,
+              reportNode: declarator,
+              scopeContainer: getNearestScopeContainer(declarator),
             });
             continue;
           }
 
-          if (
-            init &&
-            (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') &&
-            bodyCallsBuildWrapper(init.body)
-          ) {
-            context.report({
-              node: declarator,
-              messageId: 'noModuleScopeWrapperHelper',
-              data: { name },
+          if (isOverridesOnlyFactory(init)) {
+            overrideCandidates.push({
+              name,
+              reportNode: declarator,
+              scopeContainer: getNearestScopeContainer(declarator),
             });
-            continue;
           }
+        }
+      },
 
-          if (looksLikeSetupData(init)) {
+      CallExpression(node) {
+        const { callee } = node;
+        if (callee.type !== 'Identifier') return;
+        callSites.push({ name: callee.name, argCount: node.arguments.length, node });
+      },
+
+      'Program:exit'() {
+        for (const candidate of zeroArgCandidates) {
+          const matchingCalls = callSites.filter(
+            (call) =>
+              call.name === candidate.name && isWithinScope(call.node, candidate.scopeContainer)
+          );
+          // Not actually called from test code — e.g. a React component only ever
+          // referenced as JSX (`<Foo />`), which never appears as a CallExpression.
+          if (matchingCalls.length === 0) continue;
+          context.report({
+            node: candidate.reportNode,
+            messageId: 'noZeroArgFixture',
+            data: { name: candidate.name },
+          });
+        }
+
+        for (const candidate of overrideCandidates) {
+          const matchingCalls = callSites.filter(
+            (call) =>
+              call.name === candidate.name && isWithinScope(call.node, candidate.scopeContainer)
+          );
+          if (matchingCalls.length === 0) continue;
+          if (matchingCalls.every((call) => call.argCount === 0)) {
             context.report({
-              node: declarator,
-              messageId: 'noModuleScopeSetupConst',
-              data: { name },
+              node: candidate.reportNode,
+              messageId: 'noUnusedOverridesFixture',
+              data: { name: candidate.name },
             });
           }
         }

--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -86,20 +86,6 @@ describe('Deployment list page', () => {
 
 describe('Deployment detail page', () => {
   describe('header', () => {
-    const buildDeployment = (overrides = {}) => ({
-      metadata: {
-        name: 'sentiment-deployment',
-        creationTimestamp: { seconds: 1746000000 },
-        labels: { 'michelangelo/owner': 'user-example' },
-      },
-      status: {
-        state: DEPLOYMENT_STATE.HEALTHY,
-        stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
-        conditions: [] as object[],
-      },
-      ...overrides,
-    });
-
     it('renders details for deployment', async () => {
       render(
         <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
@@ -110,12 +96,15 @@ describe('Deployment detail page', () => {
           }),
           getServiceProviderWrapper({
             request: createQueryMockRouter({
-              GetDeployment: { deployment: buildDeployment() },
+              GetDeployment: {
+                deployment: {},
+              },
             }),
           }),
         ])
       );
 
+      // The header title comes from the route's entity ID, not deployment.metadata.name.
       expect(screen.getByText('sentiment-deployment')).toBeInTheDocument();
       expect(await screen.findByText('Created')).toBeInTheDocument();
       expect(screen.getByText('Owner')).toBeInTheDocument();
@@ -125,42 +114,6 @@ describe('Deployment detail page', () => {
   });
 
   describe('information tab', () => {
-    const buildDeployment = () => ({
-      metadata: {
-        name: 'sentiment-deployment',
-        creationTimestamp: { seconds: 1746000000 },
-        labels: { 'michelangelo/owner': 'user-example' },
-      },
-      spec: {
-        definition: { type: 1 },
-        strategy: { rolloutStrategy: { case: 'rolling', value: {} } },
-        target: { case: 'inferenceServer', value: { name: 'triton-server' } },
-        desiredRevision: { name: 'sentiment-model-rev-3' },
-        resourceLinks: { Dashboard: 'https://grafana.example.com/d/abc' },
-      },
-      status: {
-        state: DEPLOYMENT_STATE.HEALTHY,
-        stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
-        message: 'Rollout completed successfully.',
-        currentRevision: { name: 'sentiment-model-rev-2' },
-        conditions: [] as object[],
-      },
-    });
-
-    const buildModel = () => ({
-      metadata: { creationTimestamp: { seconds: 1746000000 } },
-      spec: {
-        owner: { name: 'model-owner' },
-        kind: 2,
-        sourcePipelineRun: { name: 'run-20260825-080000' },
-      },
-    });
-
-    const infoTabResponses = () => ({
-      GetDeployment: { deployment: buildDeployment() },
-      GetModel: { model: buildModel() },
-    });
-
     it('renders the configuration details', async () => {
       render(
         <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
@@ -169,7 +122,15 @@ describe('Deployment detail page', () => {
           getRouterWrapper({
             location: '/myproject/deploy/deployments/sentiment-deployment/info',
           }),
-          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: {
+                  spec: { definition: { type: 1 } },
+                },
+              },
+            }),
+          }),
         ])
       );
 
@@ -185,7 +146,17 @@ describe('Deployment detail page', () => {
           getRouterWrapper({
             location: '/myproject/deploy/deployments/sentiment-deployment/info',
           }),
-          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: {
+                  spec: {
+                    target: { case: 'inferenceServer', value: { name: 'triton-server' } },
+                  },
+                },
+              },
+            }),
+          }),
         ])
       );
 
@@ -223,7 +194,26 @@ describe('Deployment detail page', () => {
           getRouterWrapper({
             location: '/myproject/deploy/deployments/sentiment-deployment/info',
           }),
-          getServiceProviderWrapper({ request: createQueryMockRouter(infoTabResponses()) }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: {
+                  spec: { desiredRevision: { name: 'sentiment-model-rev-3' } },
+                  status: { currentRevision: { name: 'sentiment-model-rev-2' } },
+                },
+              },
+              GetModel: {
+                model: {
+                  metadata: { creationTimestamp: { seconds: 1746000000 } },
+                  spec: {
+                    owner: { name: 'model-owner' },
+                    kind: 2,
+                    sourcePipelineRun: { name: 'run-20260825-080000' },
+                  },
+                },
+              },
+            }),
+          }),
         ])
       );
 
@@ -244,7 +234,12 @@ describe('Deployment detail page', () => {
           }),
           getServiceProviderWrapper({
             request: createQueryMockRouter({
-              GetDeployment: { deployment: buildDeployment() },
+              GetDeployment: {
+                deployment: {
+                  spec: { desiredRevision: { name: 'sentiment-model-rev-3' } },
+                  status: { currentRevision: { name: 'sentiment-model-rev-2' } },
+                },
+              },
               GetModel: {},
             }),
           }),
@@ -273,11 +268,7 @@ describe('Deployment detail page', () => {
           getServiceProviderWrapper({
             request: createQueryMockRouter({
               GetDeployment: {
-                deployment: {
-                  metadata: { name: 'sentiment-deployment' },
-                  spec: { definition: { type: 1 } },
-                  status: { state: DEPLOYMENT_STATE.EMPTY, stage: DEPLOYMENT_STAGE.INVALID },
-                },
+                deployment: {},
               },
             }),
           }),
@@ -292,11 +283,6 @@ describe('Deployment detail page', () => {
 
   describe('ongoing operations tab', () => {
     const buildDeployment = (overrides = {}) => ({
-      metadata: {
-        name: 'sentiment-deployment',
-        creationTimestamp: { seconds: 1746000000 },
-        labels: { 'michelangelo/owner': 'user-example' },
-      },
       status: {
         state: DEPLOYMENT_STATE.HEALTHY,
         stage: DEPLOYMENT_STAGE.ROLLOUT_COMPLETE,
@@ -454,14 +440,6 @@ describe('Deployment retire action', () => {
     };
   }
 
-  function buildRetireMockRequest() {
-    return createQueryMockRouter({
-      UpdateDeployment: {
-        deployment: { metadata: { name: DEPLOYMENT_NAME, namespace: NAMESPACE } },
-      },
-    });
-  }
-
   async function openRetireDialog(user: ReturnType<typeof userEvent.setup>) {
     await user.click(screen.getByRole('button', { name: 'Actions' }));
     await user.click(await screen.findByRole('option', { name: 'Retire' }));
@@ -476,7 +454,11 @@ describe('Deployment retire action', () => {
 
   it('confirms the retire in a dialog, submits the spec with desiredRevision removed, and toasts', async () => {
     const user = userEvent.setup();
-    const request = buildRetireMockRequest();
+    const request = createQueryMockRouter({
+      UpdateDeployment: {
+        deployment: { metadata: { name: DEPLOYMENT_NAME, namespace: NAMESPACE } },
+      },
+    });
 
     render(
       <InterpolatableActionsPopover actions={RETIRE_ACTIONS} record={buildDeployedRecord()} />,
@@ -519,7 +501,11 @@ describe('Deployment retire action', () => {
 
   it('disables retire with a tooltip when the deployment has no revision to retire', async () => {
     const user = userEvent.setup();
-    const request = buildRetireMockRequest();
+    const request = createQueryMockRouter({
+      UpdateDeployment: {
+        deployment: { metadata: { name: DEPLOYMENT_NAME, namespace: NAMESPACE } },
+      },
+    });
 
     const record = buildDeployedRecord({
       spec: { target: { case: 'inferenceServer', value: { name: 'inference-server-example' } } },
@@ -552,7 +538,11 @@ describe('Deployment retire action', () => {
 
   it('stays enabled while a candidate revision is still rolling out', async () => {
     const user = userEvent.setup();
-    const request = buildRetireMockRequest();
+    const request = createQueryMockRouter({
+      UpdateDeployment: {
+        deployment: { metadata: { name: DEPLOYMENT_NAME, namespace: NAMESPACE } },
+      },
+    });
 
     // desiredRevision already cleared but a candidate is mid-rollout — retiring must
     // still be possible to abort the rollout, matching the backend's cleanup trigger.

--- a/javascript/packages/core/config/entities/model/__tests__/model-detail-page.test.tsx
+++ b/javascript/packages/core/config/entities/model/__tests__/model-detail-page.test.tsx
@@ -12,23 +12,7 @@ import {
 
 describe('Model detail page', () => {
   describe('header', () => {
-    const buildModel = (overrides: Record<string, unknown> = {}) => ({
-      metadata: {
-        name: 'fraud-classifier',
-        creationTimestamp: { seconds: 1700000000 },
-      },
-      spec: {
-        owner: { name: 'jsmith' },
-        // The generated proto client decodes enum fields to their numeric discriminant
-        // (MODEL_KIND_BINARY_CLASSIFICATION = 3), not the enum's string name.
-        kind: 3,
-        sourcePipelineRun: { name: 'fraud-classifier-run-1' },
-        description: 'Fraud detection model trained on transaction history.',
-      },
-      ...overrides,
-    });
-
-    function renderDetail(model: object) {
+    it('renders header metadata for the model', async () => {
       render(
         <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
         buildWrapper([
@@ -37,14 +21,28 @@ describe('Model detail page', () => {
             location: '/myproject/train/models/fraud-classifier/information',
           }),
           getServiceProviderWrapper({
-            request: createQueryMockRouter({ GetModel: { model } }),
+            request: createQueryMockRouter({
+              GetModel: {
+                model: {
+                  metadata: {
+                    name: 'fraud-classifier',
+                    creationTimestamp: { seconds: 1700000000 },
+                  },
+                  spec: {
+                    owner: { name: 'jsmith' },
+                    // The generated proto client decodes enum fields to their numeric
+                    // discriminant (MODEL_KIND_BINARY_CLASSIFICATION = 3), not the enum's
+                    // string name.
+                    kind: 3,
+                    sourcePipelineRun: { name: 'fraud-classifier-run-1' },
+                    description: 'Fraud detection model trained on transaction history.',
+                  },
+                },
+              },
+            }),
           }),
         ])
       );
-    }
-
-    it('renders header metadata for the model', async () => {
-      renderDetail(buildModel());
 
       expect(screen.getByText('fraud-classifier')).toBeInTheDocument();
       expect(await screen.findByText('Source pipeline run')).toBeInTheDocument();
@@ -60,22 +58,6 @@ describe('Model detail page', () => {
   });
 
   describe('information tab', () => {
-    const buildModel = () => ({
-      metadata: { name: 'fraud-classifier', creationTimestamp: { seconds: 1700000000 } },
-      spec: {
-        owner: { name: 'jsmith' },
-        sourcePipelineRun: { name: 'fraud-classifier-run-1' },
-        description: 'Fraud detection model trained on transaction history.',
-        modelFamily: { name: 'fraud-classifier-family' },
-        trainingFramework: 'TensorFlow',
-        source: 'canvas',
-        predictionResult: {
-          trainTableName: 'fraud_classifier_train_eval',
-          testTableName: 'fraud_classifier_validation_eval',
-        },
-      },
-    });
-
     function renderInformationTab() {
       render(
         <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
@@ -85,7 +67,28 @@ describe('Model detail page', () => {
             location: '/myproject/train/models/fraud-classifier/information',
           }),
           getServiceProviderWrapper({
-            request: createQueryMockRouter({ GetModel: { model: buildModel() } }),
+            request: createQueryMockRouter({
+              GetModel: {
+                model: {
+                  metadata: {
+                    name: 'fraud-classifier',
+                    creationTimestamp: { seconds: 1700000000 },
+                  },
+                  spec: {
+                    owner: { name: 'jsmith' },
+                    sourcePipelineRun: { name: 'fraud-classifier-run-1' },
+                    description: 'Fraud detection model trained on transaction history.',
+                    modelFamily: { name: 'fraud-classifier-family' },
+                    trainingFramework: 'TensorFlow',
+                    source: 'canvas',
+                    predictionResult: {
+                      trainTableName: 'fraud_classifier_train_eval',
+                      testTableName: 'fraud_classifier_validation_eval',
+                    },
+                  },
+                },
+              },
+            }),
           }),
         ])
       );

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -491,14 +491,6 @@ describe('CreatePipelineRunForm', () => {
       );
     }
 
-    function buildRequest() {
-      return createQueryMockRouter({
-        CreatePipelineRun: {},
-        ListPipelineRun: runListResponse,
-        GetPipelineRun: sourceRunResponse,
-      });
-    }
-
     async function openResumeGroup(user: ReturnType<typeof userEvent.setup>) {
       await user.click(screen.getByText('Select run to resume from'));
     }
@@ -510,7 +502,13 @@ describe('CreatePipelineRunForm', () => {
 
     it('offers only finished runs of this pipeline', async () => {
       const user = userEvent.setup();
-      renderForm(buildRequest());
+      renderForm(
+        createQueryMockRouter({
+          CreatePipelineRun: {},
+          ListPipelineRun: runListResponse,
+          GetPipelineRun: sourceRunResponse,
+        })
+      );
 
       await screen.findByRole('dialog', { name: 'Start new pipeline run' });
       await openResumeGroup(user);
@@ -524,7 +522,13 @@ describe('CreatePipelineRunForm', () => {
 
     it('populates the step picker from Execute Workflow sub-steps once a run is chosen', async () => {
       const user = userEvent.setup();
-      renderForm(buildRequest());
+      renderForm(
+        createQueryMockRouter({
+          CreatePipelineRun: {},
+          ListPipelineRun: runListResponse,
+          GetPipelineRun: sourceRunResponse,
+        })
+      );
 
       await screen.findByRole('dialog', { name: 'Start new pipeline run' });
       await openResumeGroup(user);
@@ -546,7 +550,11 @@ describe('CreatePipelineRunForm', () => {
 
     it('submits resumeFrom using step displayName, not the task path', async () => {
       const user = userEvent.setup();
-      const mockRequest = buildRequest();
+      const mockRequest = createQueryMockRouter({
+        CreatePipelineRun: {},
+        ListPipelineRun: runListResponse,
+        GetPipelineRun: sourceRunResponse,
+      });
       renderForm(mockRequest);
 
       const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
@@ -579,7 +587,11 @@ describe('CreatePipelineRunForm', () => {
 
     it('submits resume without resumeFrom when no step is picked', async () => {
       const user = userEvent.setup();
-      const mockRequest = buildRequest();
+      const mockRequest = createQueryMockRouter({
+        CreatePipelineRun: {},
+        ListPipelineRun: runListResponse,
+        GetPipelineRun: sourceRunResponse,
+      });
       renderForm(mockRequest);
 
       const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
@@ -603,7 +615,11 @@ describe('CreatePipelineRunForm', () => {
 
     it('omits the resume spec entirely when the group is opened but nothing is chosen', async () => {
       const user = userEvent.setup();
-      const router = buildRequest();
+      const router = createQueryMockRouter({
+        CreatePipelineRun: {},
+        ListPipelineRun: runListResponse,
+        GetPipelineRun: sourceRunResponse,
+      });
 
       // Captures the payload so the assertion can check for the *absence* of a key,
       // which call matchers express poorly.

--- a/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
@@ -22,27 +22,6 @@ import {
 } from '#core/test/wrappers/get-service-provider-wrapper';
 import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
 
-import type { PhaseConfig } from '#core/types/common/studio-types';
-
-function buildPipeline() {
-  return {
-    metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
-    spec: { owner: { name: 'me' } },
-  };
-}
-
-function buildTestPhases(): Record<string, PhaseConfig> {
-  return {
-    train: {
-      id: 'train',
-      icon: 'train',
-      name: 'Train',
-      state: 'active',
-      entities: [PIPELINE_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
-    },
-  };
-}
-
 // baseui's dialog dismiss button renders an icon component it internally names "Delete"
 // (unrelated to our action) with no aria-label, so it collides with the confirm button's
 // accessible name. Scope to the button-dock footer to find the real submit button.
@@ -56,7 +35,17 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
   describe('list view', () => {
     function renderList(mockRequest: ReturnType<typeof createQueryMockRouter>) {
       render(
-        <PhaseListRoute phases={buildTestPhases()} />,
+        <PhaseListRoute
+          phases={{
+            train: {
+              id: 'train',
+              icon: 'train',
+              name: 'Train',
+              state: 'active',
+              entities: [PIPELINE_ENTITY_CONFIG],
+            },
+          }}
+        />,
         buildWrapper([
           getBaseProviderWrapper(),
           getErrorProviderWrapper(),
@@ -72,7 +61,16 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
     it('opens dialog to confirm deletion of pipeline and deletes pipeline', async () => {
       const user = userEvent.setup();
       const mockRequest = createQueryMockRouter({
-        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+        ListPipeline: {
+          pipelineList: {
+            items: [
+              {
+                metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+                spec: { owner: { name: 'me' } },
+              },
+            ],
+          },
+        },
         DeletePipeline: {},
       });
 
@@ -92,7 +90,14 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
       // ({ name, namespace }) the backend expects happens in the RPC handler (see
       // packages/rpc/handlers.ts's deleteCrd), not in client-side mutation middleware.
       await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith('DeletePipeline', buildPipeline(), {});
+        expect(mockRequest).toHaveBeenCalledWith(
+          'DeletePipeline',
+          {
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+          {}
+        );
       });
 
       // Navigation is a success operation that runs after the mutation resolves, i.e.
@@ -106,7 +111,16 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
     it('keeps the dialog open and shows the error when delete fails', async () => {
       const user = userEvent.setup();
       const mockRequest = createQueryMockRouter({
-        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+        ListPipeline: {
+          pipelineList: {
+            items: [
+              {
+                metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+                spec: { owner: { name: 'me' } },
+              },
+            ],
+          },
+        },
         DeletePipeline: new Error('Delete failed'),
       });
 
@@ -125,7 +139,17 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
   describe('pipeline detail page', () => {
     function renderDetail(mockRequest: ReturnType<typeof createQueryMockRouter>) {
       render(
-        <EntityDetailRoute phases={buildTestPhases()} />,
+        <EntityDetailRoute
+          phases={{
+            train: {
+              id: 'train',
+              icon: 'train',
+              name: 'Train',
+              state: 'active',
+              entities: [PIPELINE_ENTITY_CONFIG],
+            },
+          }}
+        />,
         buildWrapper([
           getBaseProviderWrapper(),
           getErrorProviderWrapper(),
@@ -141,7 +165,12 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
     it('opens dialog to confirm deletion of pipeline, deletes pipeline and navigates to list view', async () => {
       const user = userEvent.setup();
       const mockRequest = createQueryMockRouter({
-        GetPipeline: { pipeline: buildPipeline() },
+        GetPipeline: {
+          pipeline: {
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+        },
         ListPipelineRun: { pipelineRunList: { items: [] } },
         DeletePipeline: {},
       });
@@ -159,7 +188,14 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
       await user.click(getSubmitButton(dialog));
 
       await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith('DeletePipeline', buildPipeline(), {});
+        expect(mockRequest).toHaveBeenCalledWith(
+          'DeletePipeline',
+          {
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+          {}
+        );
       });
 
       // Navigation is a success operation that runs after the mutation resolves, i.e.
@@ -173,7 +209,12 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
     it('keeps the dialog open and shows the error when delete fails', async () => {
       const user = userEvent.setup();
       const mockRequest = createQueryMockRouter({
-        GetPipeline: { pipeline: buildPipeline() },
+        GetPipeline: {
+          pipeline: {
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+        },
         ListPipelineRun: { pipelineRunList: { items: [] } },
         DeletePipeline: new Error('Delete failed'),
       });
@@ -195,7 +236,17 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
   describe('pipeline detail page', () => {
     function renderDetail(mockRequest: ReturnType<typeof createQueryMockRouter>) {
       render(
-        <EntityDetailRoute phases={buildTestPhases()} />,
+        <EntityDetailRoute
+          phases={{
+            train: {
+              id: 'train',
+              icon: 'train',
+              name: 'Train',
+              state: 'active',
+              entities: [PIPELINE_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
+            },
+          }}
+        />,
         buildWrapper([
           getBaseProviderWrapper(),
           getErrorProviderWrapper(),
@@ -212,7 +263,13 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
       const user = userEvent.setup();
       const mockRequest = createQueryMockRouter({
         GetPipeline: {
-          pipeline: { ...buildPipeline(), spec: { ...buildPipeline().spec, manifest: {} } },
+          pipeline: {
+            ...{
+              metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+              spec: { owner: { name: 'me' } },
+            },
+            spec: { ...{ owner: { name: 'me' } }, manifest: {} },
+          },
         },
         ListPipelineRun: { pipelineRunList: { items: [] } },
       });
@@ -231,9 +288,12 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
       const mockRequest = createQueryMockRouter({
         GetPipeline: {
           pipeline: {
-            ...buildPipeline(),
+            ...{
+              metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+              spec: { owner: { name: 'me' } },
+            },
             spec: {
-              ...buildPipeline().spec,
+              ...{ owner: { name: 'me' } },
               manifest: {
                 triggerMap: {
                   nightly: { triggerType: { case: 'cronSchedule', value: { cron: '0 2 * * *' } } },
@@ -258,7 +318,17 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
   describe('list view', () => {
     function renderList(items: object[], extraResponses: Record<string, object> = {}) {
       render(
-        <PhaseListRoute phases={buildTestPhases()} />,
+        <PhaseListRoute
+          phases={{
+            train: {
+              id: 'train',
+              icon: 'train',
+              name: 'Train',
+              state: 'active',
+              entities: [PIPELINE_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
+            },
+          }}
+        />,
         buildWrapper([
           getBaseProviderWrapper(),
           getErrorProviderWrapper(),
@@ -279,7 +349,13 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
     it('is disabled with an explanatory tooltip when the row declares a manifest with no triggers', async () => {
       const user = userEvent.setup();
       renderList([
-        { ...buildPipeline(), spec: { ...buildPipeline().spec, manifest: { triggerMap: {} } } },
+        {
+          ...{
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+          spec: { ...{ owner: { name: 'me' } }, manifest: { triggerMap: {} } },
+        },
       ]);
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
@@ -291,7 +367,22 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
     // not "no triggers" — fail open and let the dialog explain an empty trigger list.
     it('stays enabled when the row carries no manifest', async () => {
       const user = userEvent.setup();
-      renderList([buildPipeline()], { GetPipeline: { pipeline: buildPipeline() } });
+      renderList(
+        [
+          {
+            metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+            spec: { owner: { name: 'me' } },
+          },
+        ],
+        {
+          GetPipeline: {
+            pipeline: {
+              metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+              spec: { owner: { name: 'me' } },
+            },
+          },
+        }
+      );
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Run trigger' }));
@@ -318,7 +409,17 @@ describe('PIPELINE_DETAIL_CONFIG: runs tab', () => {
     });
 
     render(
-      <EntityDetailRoute phases={buildTestPhases()} />,
+      <EntityDetailRoute
+        phases={{
+          train: {
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            state: 'active',
+            entities: [PIPELINE_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
+          },
+        }}
+      />,
       buildWrapper([
         getBaseProviderWrapper(),
         getErrorProviderWrapper(),
@@ -363,7 +464,12 @@ describe('PIPELINE_ENTITY_CONFIG: Triggers tab', () => {
   it('lists trigger runs scoped to this pipeline, linking each to its detail page', async () => {
     const user = userEvent.setup();
     const mockRequest = createQueryMockRouter({
-      GetPipeline: { pipeline: buildPipeline() },
+      GetPipeline: {
+        pipeline: {
+          metadata: { name: 'eval-pipeline', namespace: 'ma-dev-test' },
+          spec: { owner: { name: 'me' } },
+        },
+      },
       [`ListTriggerRun:{"listOptions":{"fieldSelector":"${TRIGGER_RUN_SELECTOR}"},"namespace":"ma-dev-test"}`]:
         {
           triggerRunList: {
@@ -383,7 +489,17 @@ describe('PIPELINE_ENTITY_CONFIG: Triggers tab', () => {
     });
 
     render(
-      <EntityDetailRoute phases={buildTestPhases()} />,
+      <EntityDetailRoute
+        phases={{
+          train: {
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            state: 'active',
+            entities: [PIPELINE_ENTITY_CONFIG, TRIGGER_ENTITY_CONFIG],
+          },
+        }}
+      />,
       buildWrapper([
         getBaseProviderWrapper(),
         getErrorProviderWrapper(),

--- a/javascript/packages/core/config/entities/pipeline/__tests__/run-trigger-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/run-trigger-form.test.tsx
@@ -15,16 +15,6 @@ import {
 } from '#core/test/wrappers/get-service-provider-wrapper';
 
 describe('RunTriggerForm', () => {
-  function buildCronTrigger() {
-    return { triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } } };
-  }
-
-  function buildIntervalTrigger() {
-    return {
-      triggerType: { case: 'intervalSchedule' as const, value: { interval: { seconds: 3600 } } },
-    };
-  }
-
   /**
    * The form populates the dropdown from a fresh `GetPipeline` fetch rather than from the
    * record it opened with (see run-trigger-form.tsx), so this response — not the record —
@@ -65,8 +55,15 @@ describe('RunTriggerForm', () => {
         getServiceProviderWrapper({
           request: createQueryMockRouter({
             GetPipeline: buildPipelineResponse({
-              nightly: buildCronTrigger(),
-              hourly: buildIntervalTrigger(),
+              nightly: {
+                triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } },
+              },
+              hourly: {
+                triggerType: {
+                  case: 'intervalSchedule' as const,
+                  value: { interval: { seconds: 3600 } },
+                },
+              },
             }),
           }),
         }),
@@ -87,7 +84,9 @@ describe('RunTriggerForm', () => {
    */
   it('copies the selected trigger into the created TriggerRun', async () => {
     const user = userEvent.setup();
-    const cronTrigger = buildCronTrigger();
+    const cronTrigger = {
+      triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } },
+    };
     const request = createQueryMockRouter({
       GetPipeline: buildPipelineResponse({ nightly: cronTrigger }),
       CreateTriggerRun: {
@@ -143,7 +142,9 @@ describe('RunTriggerForm', () => {
   it('keeps the dialog open and shows the error when the submit fails', async () => {
     const user = userEvent.setup();
     const request = createQueryMockRouter({
-      GetPipeline: buildPipelineResponse({ nightly: buildCronTrigger() }),
+      GetPipeline: buildPipelineResponse({
+        nightly: { triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } } },
+      }),
       CreateTriggerRun: new Error('Create failed'),
     });
 
@@ -171,7 +172,9 @@ describe('RunTriggerForm', () => {
 
   it('shows the autoFlip choice as disabled and "Coming soon", and always sends autoFlip false', async () => {
     const user = userEvent.setup();
-    const cronTrigger = buildCronTrigger();
+    const cronTrigger = {
+      triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } },
+    };
     const request = createQueryMockRouter({
       GetPipeline: buildPipelineResponse({ nightly: cronTrigger }),
       CreateTriggerRun: {},
@@ -235,7 +238,11 @@ describe('RunTriggerForm', () => {
         getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
-            GetPipeline: buildPipelineResponse({ nightly: buildCronTrigger() }),
+            GetPipeline: buildPipelineResponse({
+              nightly: {
+                triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } },
+              },
+            }),
           }),
         }),
       ])
@@ -254,7 +261,11 @@ describe('RunTriggerForm', () => {
 
   it('sends a backfill window and restricts the trigger to the selected parameters', async () => {
     const user = userEvent.setup();
-    const trigger = { ...buildCronTrigger(), parametersMap: { a: {}, b: {} }, maxConcurrency: 5 };
+    const trigger = {
+      ...{ triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } } },
+      parametersMap: { a: {}, b: {} },
+      maxConcurrency: 5,
+    };
     const request = createQueryMockRouter({
       GetPipeline: buildPipelineResponse({ nightly: trigger }),
       CreateTriggerRun: {},
@@ -311,7 +322,9 @@ describe('RunTriggerForm', () => {
   it('refuses to submit until a trigger is chosen', async () => {
     const user = userEvent.setup();
     const request = createQueryMockRouter({
-      GetPipeline: buildPipelineResponse({ nightly: buildCronTrigger() }),
+      GetPipeline: buildPipelineResponse({
+        nightly: { triggerType: { case: 'cronSchedule' as const, value: { cron: '0 2 * * *' } } },
+      }),
       CreateTriggerRun: {},
     });
 

--- a/javascript/packages/core/config/entities/run/__tests__/run-retry-action.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run-retry-action.test.tsx
@@ -49,21 +49,6 @@ function buildFailedRun(overrides: Record<string, unknown> = {}) {
   };
 }
 
-/** Captures CreatePipelineRun payloads with a real type, so assertions stay type-safe. */
-function buildRequestCapture() {
-  const submitted: Record<string, unknown>[] = [];
-  const request = (name: string, payload: unknown) => {
-    if (name === 'CreatePipelineRun') {
-      submitted.push(payload as Record<string, unknown>);
-      return Promise.resolve({
-        pipelineRun: { metadata: { name: NEW_RUN, namespace: NAMESPACE } },
-      });
-    }
-    return Promise.resolve({});
-  };
-  return { submitted, request };
-}
-
 async function openRetryDialog(user: ReturnType<typeof userEvent.setup>) {
   await user.click(screen.getByRole('button', { name: 'Actions' }));
   await user.click(await screen.findByRole('option', { name: 'Retry' }));
@@ -73,7 +58,16 @@ async function openRetryDialog(user: ReturnType<typeof userEvent.setup>) {
 describe('RUN_ENTITY_CONFIG: retry action', () => {
   it('creates a new run that resumes from the run being retried', async () => {
     const user = userEvent.setup();
-    const { submitted, request } = buildRequestCapture();
+    const submitted: Record<string, unknown>[] = [];
+    const request = (name: string, payload: unknown) => {
+      if (name === 'CreatePipelineRun') {
+        submitted.push(payload as Record<string, unknown>);
+        return Promise.resolve({
+          pipelineRun: { metadata: { name: NEW_RUN, namespace: NAMESPACE } },
+        });
+      }
+      return Promise.resolve({});
+    };
     const record = buildFailedRun();
 
     render(
@@ -114,7 +108,16 @@ describe('RUN_ENTITY_CONFIG: retry action', () => {
 
   it('strips the server-owned fields the API rejects or overwrites on create', async () => {
     const user = userEvent.setup();
-    const { submitted, request } = buildRequestCapture();
+    const submitted: Record<string, unknown>[] = [];
+    const request = (name: string, payload: unknown) => {
+      if (name === 'CreatePipelineRun') {
+        submitted.push(payload as Record<string, unknown>);
+        return Promise.resolve({
+          pipelineRun: { metadata: { name: NEW_RUN, namespace: NAMESPACE } },
+        });
+      }
+      return Promise.resolve({});
+    };
     const record = buildFailedRun();
 
     render(
@@ -154,7 +157,16 @@ describe('RUN_ENTITY_CONFIG: retry action', () => {
 
   it('drops resumeFrom inherited from a run that was itself resumed', async () => {
     const user = userEvent.setup();
-    const { submitted, request } = buildRequestCapture();
+    const submitted: Record<string, unknown>[] = [];
+    const request = (name: string, payload: unknown) => {
+      if (name === 'CreatePipelineRun') {
+        submitted.push(payload as Record<string, unknown>);
+        return Promise.resolve({
+          pipelineRun: { metadata: { name: NEW_RUN, namespace: NAMESPACE } },
+        });
+      }
+      return Promise.resolve({});
+    };
 
     // Retrying a resumed run must not re-force the steps that run was asked to re-execute;
     // it should reuse every cached success instead.
@@ -197,7 +209,16 @@ describe('RUN_ENTITY_CONFIG: retry action', () => {
 
   it('confirms with a toast linking to the newly created run', async () => {
     const user = userEvent.setup();
-    const { request } = buildRequestCapture();
+    const submitted: Record<string, unknown>[] = [];
+    const request = (name: string, payload: unknown) => {
+      if (name === 'CreatePipelineRun') {
+        submitted.push(payload as Record<string, unknown>);
+        return Promise.resolve({
+          pipelineRun: { metadata: { name: NEW_RUN, namespace: NAMESPACE } },
+        });
+      }
+      return Promise.resolve({});
+    };
     const record = buildFailedRun();
 
     render(

--- a/javascript/packages/core/config/entities/run/__tests__/run-triggered-by.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run-triggered-by.test.tsx
@@ -13,24 +13,6 @@ import {
 } from '#core/test/wrappers/get-service-provider-wrapper';
 
 describe('Pipeline run "Triggered by"', () => {
-  function buildTriggeredRun() {
-    return {
-      metadata: {
-        name: 'triggered-run',
-        namespace: 'myproject',
-        labels: { [TRIGGERED_BY_LABEL]: 'nightly-trigger' },
-      },
-      status: { state: 3 },
-    };
-  }
-
-  function buildManualRun() {
-    return {
-      metadata: { name: 'manual-run', namespace: 'myproject' },
-      status: { state: 3 },
-    };
-  }
-
   it('links a triggered run back to its trigger in the runs list', async () => {
     render(
       <PhaseListRoute phases={{ train: TRAIN_PHASE }} />,
@@ -39,7 +21,20 @@ describe('Pipeline run "Triggered by"', () => {
         getRouterWrapper({ location: '/myproject/train/runs' }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
-            ListPipelineRun: { pipelineRunList: { items: [buildTriggeredRun()] } },
+            ListPipelineRun: {
+              pipelineRunList: {
+                items: [
+                  {
+                    metadata: {
+                      name: 'triggered-run',
+                      namespace: 'myproject',
+                      labels: { [TRIGGERED_BY_LABEL]: 'nightly-trigger' },
+                    },
+                    status: { state: 3 },
+                  },
+                ],
+              },
+            },
           }),
         }),
       ])
@@ -59,7 +54,16 @@ describe('Pipeline run "Triggered by"', () => {
         getRouterWrapper({ location: '/myproject/train/runs' }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
-            ListPipelineRun: { pipelineRunList: { items: [buildManualRun()] } },
+            ListPipelineRun: {
+              pipelineRunList: {
+                items: [
+                  {
+                    metadata: { name: 'manual-run', namespace: 'myproject' },
+                    status: { state: 3 },
+                  },
+                ],
+              },
+            },
           }),
         }),
       ])
@@ -79,7 +83,16 @@ describe('Pipeline run "Triggered by"', () => {
         getRouterWrapper({ location: '/myproject/train/runs/triggered-run' }),
         getServiceProviderWrapper({
           request: createQueryMockRouter({
-            GetPipelineRun: { pipelineRun: buildTriggeredRun() },
+            GetPipelineRun: {
+              pipelineRun: {
+                metadata: {
+                  name: 'triggered-run',
+                  namespace: 'myproject',
+                  labels: { [TRIGGERED_BY_LABEL]: 'nightly-trigger' },
+                },
+                status: { state: 3 },
+              },
+            },
           }),
         }),
       ])

--- a/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
@@ -103,19 +103,6 @@ describe('Run list page', () => {
 
 describe('Run detail page', () => {
   describe('configuration tab', () => {
-    const buildManifestContent = () => ({
-      typeUrl: 'type.googleapis.com/michelangelo.PredictionPipelineConf',
-      value: {
-        meta: {
-          workflow_version: 'v2',
-          app: 'data.michelangelo.asl.app.prediction.PredictionPipeline',
-        },
-        triggers: {
-          'daily-01': { cron: '0 01 * * *' },
-        },
-      },
-    });
-
     const buildRun = (overrides: Record<string, unknown> = {}) => ({
       metadata: { name: 'run-1', creationTimestamp: { seconds: 1700000000 } },
       spec: {
@@ -132,7 +119,18 @@ describe('Run detail page', () => {
                 // discriminant (PIPELINE_MANIFEST_TYPE_YAML = 1), not the enum's string name.
                 type: 1,
                 filePath: 'python/examples/boston/pipeline.yaml',
-                content: buildManifestContent(),
+                content: {
+                  typeUrl: 'type.googleapis.com/michelangelo.PredictionPipelineConf',
+                  value: {
+                    meta: {
+                      workflow_version: 'v2',
+                      app: 'data.michelangelo.asl.app.prediction.PredictionPipeline',
+                    },
+                    triggers: {
+                      'daily-01': { cron: '0 01 * * *' },
+                    },
+                  },
+                },
               },
             },
           },
@@ -172,7 +170,21 @@ describe('Run detail page', () => {
         spec: {
           actor: { name: 'jsmith' },
           pipelineSpec: {
-            manifest: { type: 1, content: buildManifestContent() },
+            manifest: {
+              type: 1,
+              content: {
+                typeUrl: 'type.googleapis.com/michelangelo.PredictionPipelineConf',
+                value: {
+                  meta: {
+                    workflow_version: 'v2',
+                    app: 'data.michelangelo.asl.app.prediction.PredictionPipeline',
+                  },
+                  triggers: {
+                    'daily-01': { cron: '0 01 * * *' },
+                  },
+                },
+              },
+            },
           },
         },
         status: { state: 1 },

--- a/javascript/packages/core/config/entities/trigger/__tests__/trigger-recent-runs.test.tsx
+++ b/javascript/packages/core/config/entities/trigger/__tests__/trigger-recent-runs.test.tsx
@@ -14,8 +14,14 @@ import {
 describe('Trigger detail "Recent Runs"', () => {
   const SELECTOR = `${TRIGGERED_BY_LABEL}=nightly-trigger`;
 
-  function buildMockRequest() {
-    return createQueryMockRouter({
+  /**
+   * The runs this trigger produced are found only through the label selector. The
+   * storage layer drops `listOptions.labelSelector` outright if a caller ever also
+   * sets `listOptionsExt.operation` (go/storage/mysql/mysql.go), which would silently
+   * turn this tab into a list of every run in the namespace. Pin the exact request.
+   */
+  it('lists runs filtered by the triggered-by label for this trigger', async () => {
+    const request = createQueryMockRouter({
       GetTriggerRun: {
         triggerRun: {
           metadata: { name: 'nightly-trigger', namespace: 'myproject' },
@@ -34,16 +40,6 @@ describe('Trigger detail "Recent Runs"', () => {
         },
       },
     });
-  }
-
-  /**
-   * The runs this trigger produced are found only through the label selector. The
-   * storage layer drops `listOptions.labelSelector` outright if a caller ever also
-   * sets `listOptionsExt.operation` (go/storage/mysql/mysql.go), which would silently
-   * turn this tab into a list of every run in the namespace. Pin the exact request.
-   */
-  it('lists runs filtered by the triggered-by label for this trigger', async () => {
-    const request = buildMockRequest();
 
     render(
       <EntityDetailRoute phases={{ retrain: RETRAIN_PHASE }} />,
@@ -71,7 +67,31 @@ describe('Trigger detail "Recent Runs"', () => {
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/retrain/triggers/nightly-trigger' }),
-        getServiceProviderWrapper({ request: buildMockRequest() }),
+        getServiceProviderWrapper({
+          request: createQueryMockRouter({
+            GetTriggerRun: {
+              triggerRun: {
+                metadata: { name: 'nightly-trigger', namespace: 'myproject' },
+                spec: { pipeline: { name: 'my-pipeline', namespace: 'myproject' } },
+                status: { state: 1 },
+              },
+            },
+            [`ListPipelineRun:{"listOptions":{"labelSelector":"${SELECTOR}"},"namespace":"myproject"}`]:
+              {
+                pipelineRunList: {
+                  items: [
+                    {
+                      metadata: {
+                        name: 'run-1',
+                        labels: { [TRIGGERED_BY_LABEL]: 'nightly-trigger' },
+                      },
+                      status: { state: 3 },
+                    },
+                  ],
+                },
+              },
+          }),
+        }),
       ])
     );
 

--- a/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
+++ b/javascript/packages/core/router/__tests__/phase-list-route.test.tsx
@@ -16,63 +16,11 @@ import {
 } from '../__fixtures__/phase-config-factory';
 import { PhaseListRoute } from '../phase-list-route';
 
-import type { PhaseConfig } from '#core/types/common/studio-types';
-
 describe('PhaseListRoute', () => {
   const buildEntity = buildEntityConfigFactory();
   const buildPhase = buildPhaseConfigFactory();
   const buildTableConfig = buildTableConfigFactory({
     columns: [{ id: 'name', label: 'Name', type: CellType.TEXT }],
-  });
-
-  const buildTestPhaseEntityConfig = (): Record<string, PhaseConfig> => ({
-    train: buildPhase({
-      id: 'train',
-      icon: 'train',
-      name: 'Train',
-      entities: [
-        buildEntity({
-          id: 'pipelines',
-          name: 'Pipelines',
-          service: 'pipeline',
-        }),
-        buildEntity({
-          id: 'runs',
-          name: 'Pipeline Runs',
-          service: 'pipelineRun',
-        }),
-        buildEntity({
-          id: 'disabled-entity',
-          name: 'Disabled Entity',
-          service: 'disabled',
-          state: 'disabled',
-          views: [
-            {
-              type: 'list',
-              tableConfig: buildTableConfig(),
-            },
-          ],
-        }),
-      ],
-    }),
-    evaluate: buildPhase({
-      id: 'evaluate',
-      icon: 'evaluate',
-      name: 'Evaluate',
-      entities: [
-        buildEntity({
-          id: 'evaluations',
-          name: 'Evaluations',
-          service: 'evaluation',
-          views: [
-            {
-              type: 'list',
-              tableConfig: buildTableConfig(),
-            },
-          ],
-        }),
-      ],
-    }),
   });
 
   test('renders tabs for active entities only, filtering out disabled ones', () => {
@@ -81,7 +29,39 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
@@ -96,7 +76,17 @@ describe('PhaseListRoute', () => {
 
   test('shows error message for unknown phase', () => {
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({ id: 'train', icon: 'train', name: 'Train', entities: [] }),
+          evaluate: buildPhase({
+            id: 'evaluate',
+            icon: 'evaluate',
+            name: 'Evaluate',
+            entities: [],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/unknown-phase/entity' }),
@@ -151,7 +141,39 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train' }),
@@ -168,7 +190,39 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/runs' }),
@@ -192,7 +246,39 @@ describe('PhaseListRoute', () => {
     });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/invalid-entity' }),
@@ -207,7 +293,39 @@ describe('PhaseListRoute', () => {
     const mockRequest = vi.fn().mockRejectedValue(new Error('Network error'));
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),
@@ -238,7 +356,39 @@ describe('PhaseListRoute', () => {
       });
 
     render(
-      <PhaseListRoute phases={buildTestPhaseEntityConfig()} />,
+      <PhaseListRoute
+        phases={{
+          train: buildPhase({
+            id: 'train',
+            icon: 'train',
+            name: 'Train',
+            entities: [
+              buildEntity({
+                id: 'pipelines',
+                name: 'Pipelines',
+                service: 'pipeline',
+              }),
+              buildEntity({
+                id: 'runs',
+                name: 'Pipeline Runs',
+                service: 'pipelineRun',
+              }),
+              buildEntity({
+                id: 'disabled-entity',
+                name: 'Disabled Entity',
+                service: 'disabled',
+                state: 'disabled',
+                views: [
+                  {
+                    type: 'list',
+                    tableConfig: buildTableConfig(),
+                  },
+                ],
+              }),
+            ],
+          }),
+        }}
+      />,
       buildWrapper([
         getErrorProviderWrapper(),
         getRouterWrapper({ location: '/myproject/train/pipelines' }),


### PR DESCRIPTION
## Summary

Extends the `no-module-scope-test-setup` ESLint rule with two new checks that catch a pattern the existing checks missed: a function wrapper around test data that provides no actual variability.

- **Zero-arg fixtures** — a function/arrow at module or describe scope that takes no parameters and returns setup data (an object/array/JSX literal, or a `build*`/`create*` call passed a literal). This is a constant pretending to be a factory: the function wrapper implies variability that doesn't exist.
- **Unused-overrides fixtures** — a `(overrides = {})` factory where no call site in its own describe block ever actually passes an argument. The `overrides` param exists only to dodge the existing literal check, without giving any test real flexibility.

Both patterns quietly defeat the rule's original intent (keeping test setup inlined and self-contained) while looking like proper factories.

### Per-scope checking

The unused-overrides check is scoped per `describe()` block, not per file. The same factory name can be defined in multiple sibling describes with different usage — e.g. a `header` describe where `buildDeployment(overrides = {})` is only ever called with no arguments, alongside an `ongoing operations` describe where a same-named `buildDeployment` genuinely uses overrides. Each copy is judged only against call sites in its own lexical scope, so the used copy doesn't mask the unused one (or vice versa).

### JSX exemption

A candidate is only flagged if test code actually calls it as a function. This avoids a false positive on a zero-arg React component that's only ever rendered as JSX (`<FormWrapper />`), which never appears as a `CallExpression` even though its body returns JSX.

## Violations fixed

Enabling the new checks surfaced 12 existing violations, fixed by inlining each literal directly where it's used rather than hoisting it back into a shared constant or `beforeEach` — sharing response data across tests is exactly the coupling that made the model-clearing test in `deployment-page.test.tsx` fragile, and none of these fixtures share mutable state that actually needs resetting between tests:

**Zero-arg fixtures:**
1. `pipeline.test.tsx` — `buildPipeline()`, `buildTestPhases()`
2. `create-pipeline-run-form.test.tsx` — `buildRequest()`
3. `deployment-page.test.tsx` (info tab) — `buildDeployment()`, `buildModel()`, `infoTabResponses()`
4. `model-detail-page.test.tsx` (info tab) — `buildModel()`
5. `run-retry-action.test.tsx` — `buildRequestCapture()`
6. `run.test.tsx` (config tab) — `buildManifestContent()`
7. `phase-list-route.test.tsx` — `buildTestPhaseEntityConfig()`

**Unused-overrides fixtures:**
8. `deployment-page.test.tsx` (header) — `buildDeployment(overrides = {})`
9. `model-detail-page.test.tsx` (header) — `buildModel(overrides = {})`

Each inlined mock was also trimmed to the fields its own test actually reads or needs to avoid the component's defensive fallbacks — e.g. `deployment-page.test.tsx`'s header test only needs an empty `deployment` object, since the header title comes from the route's entity ID and every metadata row renders its label regardless of whether the underlying value is present.

One note for review: `run-retry-action.test.tsx`'s fix keeps a local per-test closure (a `submitted` array + custom `request` fn) rather than a shared helper, because I checked `packages/core/test/` and `packages/core/components/form/` and no reusable "capture submitted mutation payloads" utility exists yet. The same pattern also appears once in `create-pipeline-run-form.test.tsx`. Worth extracting into `get-service-provider-wrapper.tsx` if it spreads further, but didn't seem justified for two call sites.

## Test plan

- Added 13 new RuleTester cases covering both checks, sibling-scope isolation, and the "never called" exclusion — all 45 rule tests pass.
- Ran the rule directly against all 132 test files in the repo: it caught exactly the 12 known violations above and nothing else, with no false positives against genuine overrides usage (`target-page.test.tsx`, `run.test.tsx`'s `buildRun`, `run-retry-action.test.tsx`'s `buildFailedRun`).
- `yarn lint` is clean across the whole `javascript/` tree.
- `yarn vitest run` passes for all affected test files individually and for the full suite (164 files, 1553 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)