### PR TITLE
Flag render-within-render helpers in no-module-scope-test-setup

### DIFF
--- a/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
+++ b/javascript/eslint-local-rules/__tests__/no-module-scope-test-setup.test.js
@@ -101,6 +101,21 @@ tester.run('no-module-scope-test-setup', rule, {
       name: 'object literal inside arrow function at describe scope',
       code: `describe('suite', () => { const build = () => { const data = { name: 'test' }; return data; }; });`,
     },
+    // render() called directly inside a test — not wrapped in a helper
+    {
+      name: 'render() inside it()',
+      code: `it('renders', () => { render(el, getWrapper()); });`,
+    },
+    {
+      name: 'module-scope helper unrelated to render',
+      code: `function buildRequest() { return createQueryMockRouter({}); }`,
+    },
+    // render() only occurs inside a nested closure the helper defines but never itself
+    // invokes — the outer helper's own body never calls render, so it isn't flagged
+    {
+      name: 'render() only inside a nested inner closure, not called by the outer helper itself',
+      code: `function setup() { const helper = () => render(el, getWrapper()); return helper; }`,
+    },
   ],
 
   invalid: [
@@ -177,6 +192,86 @@ tester.run('no-module-scope-test-setup', rule, {
       name: 'wrapper helper function at top-level describe scope',
       code: `describe('suite', () => { function buildTestWrapper(req) { return buildWrapper([getBaseProviderWrapper()]); } });`,
       errors: [{ messageId: 'noModuleScopeWrapperHelper', data: { name: 'buildTestWrapper' } }],
+    },
+    // render-within-render: function declaration wrapping render() at module scope
+    // (uses getWrapper() rather than buildWrapper() so the buildWrapper-helper check
+    // above doesn't take priority — that case is covered by the existing subset check)
+    {
+      name: 'function declaration wrapping render() at module scope',
+      code: `function renderDetail(req) { render(el, getWrapper()); }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // arrow function variable wrapping render() at module scope
+    {
+      name: 'arrow function variable wrapping render() at module scope',
+      code: `const renderDetail = (req) => { render(el, getWrapper()); };`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render-within-render at top-level describe scope
+    {
+      name: 'function declaration wrapping render() at top-level describe scope',
+      code: `describe('suite', () => { function renderDetail(req) { render(el, getWrapper()); } });`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render-within-render inside a NESTED describe — unlike shared literals, this is still flagged
+    // because wrapping render() in another helper is unnecessary indirection at any nesting depth
+    {
+      name: 'function declaration wrapping render() inside a nested describe',
+      code: `describe('outer', () => { describe('inner', () => { function renderDetail(req) { render(el, buildWrapper([getBaseProviderWrapper()])); } }); });`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    {
+      name: 'arrow function variable wrapping render() inside a nested describe',
+      code: `describe('outer', () => { describe('inner', () => { const renderDetail = (req) => { render(el, buildWrapper([getBaseProviderWrapper()])); }; }); });`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() call is nested inside another call passed to the helper — still detected
+    {
+      name: 'render() call nested as an argument inside the helper body',
+      code: `function renderDetail(req) { return someWrapperFn(render(el, getWrapper())); }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // returning the render() call directly is still a render-within-render
+    {
+      name: 'function declaration that returns render() directly',
+      code: `function setup() { return render(el, getWrapper()); }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'setup' } }],
+    },
+    // render() hidden behind an if statement
+    {
+      name: 'render() called inside an if statement',
+      code: `function renderDetail(cond) { if (cond) { render(el, getWrapper()); } }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() hidden behind an if/else statement's alternate branch
+    {
+      name: 'render() called inside an if/else alternate branch',
+      code: `function renderDetail(cond) { if (cond) { doSomethingElse(); } else { render(el, getWrapper()); } }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() hidden behind a ternary
+    {
+      name: 'render() called inside a ternary expression',
+      code: `function renderDetail(cond) { cond ? render(el, getWrapper()) : null; }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() hidden behind a logical && short-circuit
+    {
+      name: 'render() called behind a logical && short-circuit',
+      code: `function renderDetail(cond) { cond && render(el, getWrapper()); }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() hidden inside a try block
+    {
+      name: 'render() called inside a try block',
+      code: `function renderDetail() { try { render(el, getWrapper()); } catch (e) { handleError(e); } }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
+    },
+    // render() assigned to an intermediate variable before being used
+    {
+      name: 'render() called via an intermediate variable declaration',
+      code: `function renderDetail() { const result = render(el, getWrapper()); return result; }`,
+      errors: [{ messageId: 'noRenderWithinRenderHelper', data: { name: 'renderDetail' } }],
     },
   ],
 });

--- a/javascript/eslint-local-rules/no-module-scope-test-setup.js
+++ b/javascript/eslint-local-rules/no-module-scope-test-setup.js
@@ -23,6 +23,9 @@ const rule = {
       noModuleScopeWrapperHelper:
         "'{{ name }}' wraps buildWrapper() at module scope. Move the buildWrapper() call inline into each test so every test is self-contained.",
 
+      noRenderWithinRenderHelper:
+        "'{{ name }}' wraps render() in a local helper — call render() and buildWrapper() directly in each test instead.",
+
       noModuleScopeSetupConst:
         "'{{ name }}' is declared at module scope but looks like test setup (props, options, config). Inline it inside each test, or group shared setup in a nested describe with a factory function.",
     },
@@ -96,35 +99,118 @@ const rule = {
     }
 
     /**
-     * Returns true when the initializer (or any nested call) invokes buildWrapper.
+     * Like isModuleScope, but a nested describe never exempts a function here: wrapping
+     * render() in another helper is unnecessary indirection at any nesting depth, unlike
+     * shared literal setup, where a nested describe is an intentional semantic group.
      */
-    function callsBuildWrapper(node) {
-      if (!node) return false;
-      if (node.type === 'CallExpression') {
-        const { callee } = node;
-        if (callee.type === 'Identifier' && callee.name === 'buildWrapper') return true;
-        // Check arguments recursively in case it's wrapped
-        return node.arguments.some(callsBuildWrapper);
+    function isDescribeOrModuleScope(node) {
+      let current = node.parent;
+      while (current) {
+        if (current.type === 'Program') return true;
+        if (
+          (current.type === 'FunctionDeclaration' ||
+            current.type === 'FunctionExpression' ||
+            current.type === 'ArrowFunctionExpression') &&
+          isStandaloneFunction(current)
+        ) {
+          return false;
+        }
+        if (current.type === 'CallExpression') {
+          const name = getCalleeName(current);
+          if (name && TEST_HOOKS.has(name)) return false;
+          if (name === 'describe') return true;
+        }
+        current = current.parent;
       }
-      if (node.type === 'ArrayExpression') {
-        return node.elements.some(callsBuildWrapper);
-      }
-      return false;
+      return true;
     }
 
-    function bodyCallsBuildWrapper(node) {
+    function isFunctionBoundary(node) {
+      return (
+        node.type === 'FunctionDeclaration' ||
+        node.type === 'FunctionExpression' ||
+        node.type === 'ArrowFunctionExpression'
+      );
+    }
+
+    /**
+     * Walks a statement/expression tree looking for a direct call to `targetName`
+     * (e.g. `render`, `buildWrapper`), stopping at any nested function boundary — a call
+     * buried inside an inner closure isn't necessarily executed when the outer helper
+     * runs, so it doesn't count as the helper itself performing that call.
+     *
+     * Covers the shapes a call can hide behind: control flow (if/try/switch/loops),
+     * boolean/ternary short-circuiting, intermediate variables, and nested call
+     * arguments/array/object literals — not just a bare top-level statement.
+     */
+    function bodyCallsFunction(node, targetName) {
       if (!node) return false;
-      if (callsBuildWrapper(node)) return true;
-      if (node.type === 'BlockStatement') {
-        return node.body.some(bodyCallsBuildWrapper);
+
+      if (node.type === 'CallExpression') {
+        const { callee } = node;
+        if (callee.type === 'Identifier' && callee.name === targetName) return true;
+        return node.arguments.some((arg) => bodyCallsFunction(arg, targetName));
       }
-      if (node.type === 'ReturnStatement') {
-        return bodyCallsBuildWrapper(node.argument);
+
+      if (isFunctionBoundary(node)) return false;
+
+      switch (node.type) {
+        case 'Program':
+        case 'BlockStatement':
+          return node.body.some((n) => bodyCallsFunction(n, targetName));
+        case 'ExpressionStatement':
+          return bodyCallsFunction(node.expression, targetName);
+        case 'ReturnStatement':
+        case 'AwaitExpression':
+        case 'UnaryExpression':
+        case 'SpreadElement':
+        case 'YieldExpression':
+          return bodyCallsFunction(node.argument, targetName);
+        case 'IfStatement':
+          return (
+            bodyCallsFunction(node.consequent, targetName) ||
+            bodyCallsFunction(node.alternate, targetName)
+          );
+        case 'ConditionalExpression':
+          return (
+            bodyCallsFunction(node.test, targetName) ||
+            bodyCallsFunction(node.consequent, targetName) ||
+            bodyCallsFunction(node.alternate, targetName)
+          );
+        case 'LogicalExpression':
+        case 'BinaryExpression':
+        case 'AssignmentExpression':
+          return (
+            bodyCallsFunction(node.left, targetName) || bodyCallsFunction(node.right, targetName)
+          );
+        case 'SequenceExpression':
+          return node.expressions.some((n) => bodyCallsFunction(n, targetName));
+        case 'TryStatement':
+          return (
+            bodyCallsFunction(node.block, targetName) ||
+            (node.handler ? bodyCallsFunction(node.handler.body, targetName) : false) ||
+            bodyCallsFunction(node.finalizer, targetName)
+          );
+        case 'SwitchStatement':
+          return node.cases.some((c) => c.consequent.some((n) => bodyCallsFunction(n, targetName)));
+        case 'ForStatement':
+        case 'ForInStatement':
+        case 'ForOfStatement':
+        case 'WhileStatement':
+        case 'DoWhileStatement':
+        case 'LabeledStatement':
+          return bodyCallsFunction(node.body, targetName);
+        case 'VariableDeclaration':
+          return node.declarations.some((d) => bodyCallsFunction(d.init, targetName));
+        case 'ArrayExpression':
+          return node.elements.some((el) => bodyCallsFunction(el, targetName));
+        case 'ObjectExpression':
+          return node.properties.some((p) => bodyCallsFunction(p.value ?? p.argument, targetName));
+        case 'TemplateLiteral':
+          return node.expressions.some((n) => bodyCallsFunction(n, targetName));
+        default:
+          return false;
       }
-      if (node.type === 'ExpressionStatement') {
-        return bodyCallsBuildWrapper(node.expression);
-      }
-      return false;
     }
 
     /**
@@ -144,25 +230,38 @@ const rule = {
 
     return {
       FunctionDeclaration(node) {
-        if (!isModuleScope(node)) return;
         const name = node.id?.name ?? '<anonymous>';
-        if (bodyCallsBuildWrapper(node.body)) {
+
+        if (isModuleScope(node) && bodyCallsFunction(node.body, 'buildWrapper')) {
           context.report({
             node,
             messageId: 'noModuleScopeWrapperHelper',
+            data: { name },
+          });
+          return;
+        }
+
+        if (isDescribeOrModuleScope(node) && bodyCallsFunction(node.body, 'render')) {
+          context.report({
+            node,
+            messageId: 'noRenderWithinRenderHelper',
             data: { name },
           });
         }
       },
 
       VariableDeclaration(node) {
-        if (!isModuleScope(node)) return;
+        const declareScope = isModuleScope(node);
+        const renderScope = declareScope || isDescribeOrModuleScope(node);
+        if (!renderScope) return;
 
         for (const declarator of node.declarations) {
           const { init, id } = declarator;
           const name = id.type === 'Identifier' ? id.name : '<destructured>';
+          const isHelperFunction =
+            init && (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression');
 
-          if (callsBuildWrapper(init)) {
+          if (declareScope && bodyCallsFunction(init, 'buildWrapper')) {
             context.report({
               node: declarator,
               messageId: 'noModuleScopeWrapper',
@@ -170,11 +269,7 @@ const rule = {
             continue;
           }
 
-          if (
-            init &&
-            (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') &&
-            bodyCallsBuildWrapper(init.body)
-          ) {
+          if (declareScope && isHelperFunction && bodyCallsFunction(init.body, 'buildWrapper')) {
             context.report({
               node: declarator,
               messageId: 'noModuleScopeWrapperHelper',
@@ -183,7 +278,16 @@ const rule = {
             continue;
           }
 
-          if (looksLikeSetupData(init)) {
+          if (isHelperFunction && bodyCallsFunction(init.body, 'render')) {
+            context.report({
+              node: declarator,
+              messageId: 'noRenderWithinRenderHelper',
+              data: { name },
+            });
+            continue;
+          }
+
+          if (declareScope && looksLikeSetupData(init)) {
             context.report({
               node: declarator,
               messageId: 'noModuleScopeSetupConst',

--- a/javascript/packages/core/config/entities/model/__tests__/model-detail-page.test.tsx
+++ b/javascript/packages/core/config/entities/model/__tests__/model-detail-page.test.tsx
@@ -28,7 +28,7 @@ describe('Model detail page', () => {
       ...overrides,
     });
 
-    function renderDetail(model: object) {
+    it('renders header metadata for the model', async () => {
       render(
         <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
         buildWrapper([
@@ -37,14 +37,10 @@ describe('Model detail page', () => {
             location: '/myproject/train/models/fraud-classifier/information',
           }),
           getServiceProviderWrapper({
-            request: createQueryMockRouter({ GetModel: { model } }),
+            request: createQueryMockRouter({ GetModel: { model: buildModel() } }),
           }),
         ])
       );
-    }
-
-    it('renders header metadata for the model', async () => {
-      renderDetail(buildModel());
 
       expect(screen.getByText('fraud-classifier')).toBeInTheDocument();
       expect(await screen.findByText('Source pipeline run')).toBeInTheDocument();
@@ -76,7 +72,7 @@ describe('Model detail page', () => {
       },
     });
 
-    function renderInformationTab() {
+    beforeEach(() => {
       render(
         <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
         buildWrapper([
@@ -89,27 +85,21 @@ describe('Model detail page', () => {
           }),
         ])
       );
-    }
+    });
 
     it('renders the source pipeline run link in Useful links', async () => {
-      renderInformationTab();
-
       for (const link of await screen.findAllByRole('link', { name: 'fraud-classifier-run-1' })) {
         expect(link).toHaveAttribute('href', '/myproject/train/runs/fraud-classifier-run-1');
       }
     });
 
     it('renders the description', async () => {
-      renderInformationTab();
-
       expect(
         await screen.findByDisplayValue('Fraud detection model trained on transaction history.')
       ).toBeInTheDocument();
     });
 
     it('renders the model context configuration fields', async () => {
-      renderInformationTab();
-
       expect(await screen.findByText('Model context')).toBeInTheDocument();
       expect(await screen.findByRole('textbox', { name: 'Model family' })).toHaveValue(
         'fraud-classifier-family'
@@ -119,8 +109,6 @@ describe('Model detail page', () => {
     });
 
     it('renders the training setup configuration fields', async () => {
-      renderInformationTab();
-
       expect(await screen.findByText('Training setup')).toBeInTheDocument();
       expect(
         await screen.findByRole('textbox', { name: 'Train evaluation Hive table' })

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -477,20 +477,6 @@ describe('CreatePipelineRunForm', () => {
       },
     };
 
-    function renderForm(request: ReturnType<typeof createQueryMockRouter>) {
-      return render(
-        <FormWrapper />,
-        buildWrapper([
-          getBaseProviderWrapper(),
-          getIconProviderWrapper(),
-          getErrorProviderWrapper(),
-          getInterpolationProviderWrapper(),
-          getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
-          getServiceProviderWrapper({ request }),
-        ])
-      );
-    }
-
     function buildRequest() {
       return createQueryMockRouter({
         CreatePipelineRun: {},
@@ -508,96 +494,109 @@ describe('CreatePipelineRunForm', () => {
       await user.click(await screen.findByText(new RegExp(SOURCE_RUN)));
     }
 
-    it('offers only finished runs of this pipeline', async () => {
-      const user = userEvent.setup();
-      renderForm(buildRequest());
+    describe('with the default mock request', () => {
+      let mockRequest: ReturnType<typeof buildRequest>;
 
-      await screen.findByRole('dialog', { name: 'Start new pipeline run' });
-      await openResumeGroup(user);
-      await user.click(await screen.findByRole('combobox', { name: /pipeline run/i }));
-
-      expect(await screen.findByText(new RegExp(SOURCE_RUN))).toBeInTheDocument();
-      // Excluded: belongs to another pipeline, and is still running
-      expect(screen.queryByText(/run-other-pipeline/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/run-still-running/)).not.toBeInTheDocument();
-    });
-
-    it('populates the step picker from Execute Workflow sub-steps once a run is chosen', async () => {
-      const user = userEvent.setup();
-      renderForm(buildRequest());
-
-      await screen.findByRole('dialog', { name: 'Start new pipeline run' });
-      await openResumeGroup(user);
-
-      // Disabled until a source run supplies the option list
-      expect(screen.getByRole('combobox', { name: /steps/i })).toBeDisabled();
-
-      await selectSourceRun(user);
-
-      const stepPicker = await screen.findByRole('combobox', { name: /steps/i });
-      await waitFor(() => expect(stepPicker).not.toBeDisabled());
-      await user.click(stepPicker);
-
-      expect(await screen.findByText('feature_gen')).toBeInTheDocument();
-      expect(screen.getByText('train_model')).toBeInTheDocument();
-      // Platform stages are not resumable DAG tasks
-      expect(screen.queryByText('Image Build')).not.toBeInTheDocument();
-    });
-
-    it('submits resumeFrom using step displayName, not the task path', async () => {
-      const user = userEvent.setup();
-      const mockRequest = buildRequest();
-      renderForm(mockRequest);
-
-      const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
-      await openResumeGroup(user);
-      await selectSourceRun(user);
-
-      const stepPicker = await screen.findByRole('combobox', { name: /steps/i });
-      await waitFor(() => expect(stepPicker).not.toBeDisabled());
-      await user.click(stepPicker);
-      await user.click(await screen.findByText('feature_gen'));
-
-      await selectEnvironment(user, dialog, 'Development');
-      await user.click(within(dialog).getByRole('button', { name: 'Run' }));
-
-      await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith(
-          'CreatePipelineRun',
-          expect.objectContaining({
-            spec: expect.objectContaining({
-              resume: {
-                pipelineRun: { name: SOURCE_RUN, namespace: 'ma-dev-test' },
-                resumeFrom: ['feature_gen'],
-              },
-            }) as Record<string, unknown>,
-          }),
-          {}
+      beforeEach(() => {
+        mockRequest = buildRequest();
+        render(
+          <FormWrapper />,
+          buildWrapper([
+            getBaseProviderWrapper(),
+            getIconProviderWrapper(),
+            getErrorProviderWrapper(),
+            getInterpolationProviderWrapper(),
+            getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+            getServiceProviderWrapper({ request: mockRequest }),
+          ])
         );
       });
-    });
 
-    it('submits resume without resumeFrom when no step is picked', async () => {
-      const user = userEvent.setup();
-      const mockRequest = buildRequest();
-      renderForm(mockRequest);
+      it('offers only finished runs of this pipeline', async () => {
+        const user = userEvent.setup();
 
-      const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
-      await openResumeGroup(user);
-      await selectSourceRun(user);
-      await selectEnvironment(user, dialog, 'Development');
-      await user.click(within(dialog).getByRole('button', { name: 'Run' }));
+        await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+        await openResumeGroup(user);
+        await user.click(await screen.findByRole('combobox', { name: /pipeline run/i }));
 
-      await waitFor(() => {
-        expect(mockRequest).toHaveBeenCalledWith(
-          'CreatePipelineRun',
-          expect.objectContaining({
-            spec: expect.objectContaining({
-              resume: { pipelineRun: { name: SOURCE_RUN, namespace: 'ma-dev-test' } },
-            }) as Record<string, unknown>,
-          }),
-          {}
-        );
+        expect(await screen.findByText(new RegExp(SOURCE_RUN))).toBeInTheDocument();
+        // Excluded: belongs to another pipeline, and is still running
+        expect(screen.queryByText(/run-other-pipeline/)).not.toBeInTheDocument();
+        expect(screen.queryByText(/run-still-running/)).not.toBeInTheDocument();
+      });
+
+      it('populates the step picker from Execute Workflow sub-steps once a run is chosen', async () => {
+        const user = userEvent.setup();
+
+        await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+        await openResumeGroup(user);
+
+        // Disabled until a source run supplies the option list
+        expect(screen.getByRole('combobox', { name: /steps/i })).toBeDisabled();
+
+        await selectSourceRun(user);
+
+        const stepPicker = await screen.findByRole('combobox', { name: /steps/i });
+        await waitFor(() => expect(stepPicker).not.toBeDisabled());
+        await user.click(stepPicker);
+
+        expect(await screen.findByText('feature_gen')).toBeInTheDocument();
+        expect(screen.getByText('train_model')).toBeInTheDocument();
+        // Platform stages are not resumable DAG tasks
+        expect(screen.queryByText('Image Build')).not.toBeInTheDocument();
+      });
+
+      it('submits resumeFrom using step displayName, not the task path', async () => {
+        const user = userEvent.setup();
+
+        const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+        await openResumeGroup(user);
+        await selectSourceRun(user);
+
+        const stepPicker = await screen.findByRole('combobox', { name: /steps/i });
+        await waitFor(() => expect(stepPicker).not.toBeDisabled());
+        await user.click(stepPicker);
+        await user.click(await screen.findByText('feature_gen'));
+
+        await selectEnvironment(user, dialog, 'Development');
+        await user.click(within(dialog).getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+          expect(mockRequest).toHaveBeenCalledWith(
+            'CreatePipelineRun',
+            expect.objectContaining({
+              spec: expect.objectContaining({
+                resume: {
+                  pipelineRun: { name: SOURCE_RUN, namespace: 'ma-dev-test' },
+                  resumeFrom: ['feature_gen'],
+                },
+              }) as Record<string, unknown>,
+            }),
+            {}
+          );
+        });
+      });
+
+      it('submits resume without resumeFrom when no step is picked', async () => {
+        const user = userEvent.setup();
+
+        const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
+        await openResumeGroup(user);
+        await selectSourceRun(user);
+        await selectEnvironment(user, dialog, 'Development');
+        await user.click(within(dialog).getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+          expect(mockRequest).toHaveBeenCalledWith(
+            'CreatePipelineRun',
+            expect.objectContaining({
+              spec: expect.objectContaining({
+                resume: { pipelineRun: { name: SOURCE_RUN, namespace: 'ma-dev-test' } },
+              }) as Record<string, unknown>,
+            }),
+            {}
+          );
+        });
       });
     });
 
@@ -615,7 +614,17 @@ describe('CreatePipelineRunForm', () => {
         return router(queryName, args, headers);
       };
 
-      renderForm(request);
+      render(
+        <FormWrapper />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getIconProviderWrapper(),
+          getErrorProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+          getServiceProviderWrapper({ request }),
+        ])
+      );
 
       const dialog = await screen.findByRole('dialog', { name: 'Start new pipeline run' });
       await openResumeGroup(user);

--- a/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/pipeline.test.tsx
@@ -54,7 +54,13 @@ function getSubmitButton(dialog: HTMLElement) {
 
 describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
   describe('list view', () => {
-    function renderList(mockRequest: ReturnType<typeof createQueryMockRouter>) {
+    it('opens dialog to confirm deletion of pipeline and deletes pipeline', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+        DeletePipeline: {},
+      });
+
       render(
         <PhaseListRoute phases={buildTestPhases()} />,
         buildWrapper([
@@ -67,16 +73,6 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
           getSnackbarProviderWrapper(),
         ])
       );
-    }
-
-    it('opens dialog to confirm deletion of pipeline and deletes pipeline', async () => {
-      const user = userEvent.setup();
-      const mockRequest = createQueryMockRouter({
-        ListPipeline: { pipelineList: { items: [buildPipeline()] } },
-        DeletePipeline: {},
-      });
-
-      renderList(mockRequest);
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -110,7 +106,18 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
         DeletePipeline: new Error('Delete failed'),
       });
 
-      renderList(mockRequest);
+      render(
+        <PhaseListRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+          getServiceProviderWrapper({ request: mockRequest }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -123,7 +130,14 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
   });
 
   describe('pipeline detail page', () => {
-    function renderDetail(mockRequest: ReturnType<typeof createQueryMockRouter>) {
+    it('opens dialog to confirm deletion of pipeline, deletes pipeline and navigates to list view', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        GetPipeline: { pipeline: buildPipeline() },
+        ListPipelineRun: { pipelineRunList: { items: [] } },
+        DeletePipeline: {},
+      });
+
       render(
         <EntityDetailRoute phases={buildTestPhases()} />,
         buildWrapper([
@@ -136,17 +150,6 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
           getSnackbarProviderWrapper(),
         ])
       );
-    }
-
-    it('opens dialog to confirm deletion of pipeline, deletes pipeline and navigates to list view', async () => {
-      const user = userEvent.setup();
-      const mockRequest = createQueryMockRouter({
-        GetPipeline: { pipeline: buildPipeline() },
-        ListPipelineRun: { pipelineRunList: { items: [] } },
-        DeletePipeline: {},
-      });
-
-      renderDetail(mockRequest);
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -178,7 +181,18 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
         DeletePipeline: new Error('Delete failed'),
       });
 
-      renderDetail(mockRequest);
+      render(
+        <EntityDetailRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines/eval-pipeline/runs' }),
+          getServiceProviderWrapper({ request: mockRequest }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Delete' }));
@@ -193,7 +207,15 @@ describe('PIPELINE_ENTITY_CONFIG: delete action', () => {
 
 describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
   describe('pipeline detail page', () => {
-    function renderDetail(mockRequest: ReturnType<typeof createQueryMockRouter>) {
+    it('is greyed out with an explanatory tooltip when the pipeline declares no triggers', async () => {
+      const user = userEvent.setup();
+      const mockRequest = createQueryMockRouter({
+        GetPipeline: {
+          pipeline: { ...buildPipeline(), spec: { ...buildPipeline().spec, manifest: {} } },
+        },
+        ListPipelineRun: { pipelineRunList: { items: [] } },
+      });
+
       render(
         <EntityDetailRoute phases={buildTestPhases()} />,
         buildWrapper([
@@ -206,18 +228,6 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
           getSnackbarProviderWrapper(),
         ])
       );
-    }
-
-    it('is greyed out with an explanatory tooltip when the pipeline declares no triggers', async () => {
-      const user = userEvent.setup();
-      const mockRequest = createQueryMockRouter({
-        GetPipeline: {
-          pipeline: { ...buildPipeline(), spec: { ...buildPipeline().spec, manifest: {} } },
-        },
-        ListPipelineRun: { pipelineRunList: { items: [] } },
-      });
-
-      renderDetail(mockRequest);
 
       const runTriggerButton = await screen.findByRole('button', { name: 'Run trigger' });
       expect(runTriggerButton).toBeDisabled();
@@ -245,7 +255,18 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
         ListPipelineRun: { pipelineRunList: { items: [] } },
       });
 
-      renderDetail(mockRequest);
+      render(
+        <EntityDetailRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines/eval-pipeline/runs' }),
+          getServiceProviderWrapper({ request: mockRequest }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
 
       const runTriggerButton = await screen.findByRole('button', { name: 'Run trigger' });
       expect(runTriggerButton).toBeEnabled();
@@ -256,7 +277,9 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
   });
 
   describe('list view', () => {
-    function renderList(items: object[], extraResponses: Record<string, object> = {}) {
+    it('is disabled with an explanatory tooltip when the row declares a manifest with no triggers', async () => {
+      const user = userEvent.setup();
+
       render(
         <PhaseListRoute phases={buildTestPhases()} />,
         buildWrapper([
@@ -267,20 +290,21 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
           getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
           getServiceProviderWrapper({
             request: createQueryMockRouter({
-              ListPipeline: { pipelineList: { items } },
-              ...extraResponses,
+              ListPipeline: {
+                pipelineList: {
+                  items: [
+                    {
+                      ...buildPipeline(),
+                      spec: { ...buildPipeline().spec, manifest: { triggerMap: {} } },
+                    },
+                  ],
+                },
+              },
             }),
           }),
           getSnackbarProviderWrapper(),
         ])
       );
-    }
-
-    it('is disabled with an explanatory tooltip when the row declares a manifest with no triggers', async () => {
-      const user = userEvent.setup();
-      renderList([
-        { ...buildPipeline(), spec: { ...buildPipeline().spec, manifest: { triggerMap: {} } } },
-      ]);
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.hover(await screen.findByRole('option', { name: 'Run trigger' }));
@@ -291,7 +315,24 @@ describe('PIPELINE_ENTITY_CONFIG: Run trigger action', () => {
     // not "no triggers" — fail open and let the dialog explain an empty trigger list.
     it('stays enabled when the row carries no manifest', async () => {
       const user = userEvent.setup();
-      renderList([buildPipeline()], { GetPipeline: { pipeline: buildPipeline() } });
+
+      render(
+        <PhaseListRoute phases={buildTestPhases()} />,
+        buildWrapper([
+          getBaseProviderWrapper(),
+          getErrorProviderWrapper(),
+          getIconProviderWrapper(),
+          getInterpolationProviderWrapper(),
+          getRouterWrapper({ location: '/ma-dev-test/train/pipelines' }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              ListPipeline: { pipelineList: { items: [buildPipeline()] } },
+              GetPipeline: { pipeline: buildPipeline() },
+            }),
+          }),
+          getSnackbarProviderWrapper(),
+        ])
+      );
 
       await user.click(await screen.findByRole('button', { name: 'Actions' }));
       await user.click(await screen.findByRole('option', { name: 'Run trigger' }));


### PR DESCRIPTION
## Summary

The rule already caught local helpers that wrapped `buildWrapper()` at module or top-level describe scope, but that check was really pattern-matching the two known violation shapes: a bare `BlockStatement`/`ReturnStatement`/`ExpressionStatement` walk, and an exemption for nested describes that made sense for shared literal setup (a semantic grouping) but not for this pattern — a helper like `renderDetail()` that only wraps `render()`, without itself calling `buildWrapper()`, is unnecessary indirection at any nesting depth, since it just re-hides the `render()` + `buildWrapper()` abstraction the tests are supposed to call directly.

Generalized both parts: a scope check that treats any describe, nested or not, as reportable for this specific pattern, and a single statement/expression walker that follows control flow (if/else, try/catch, switch, loops, ternaries, logical short-circuits, intermediate variables) instead of only the literal shapes seen in the known violations, so it won't silently miss the next helper written slightly differently. It still stops at any nested function boundary, since a call buried inside an inner closure isn't necessarily executed by the helper itself.

Running the new check surfaced five violations rather than the four expected going in — `model-detail-page.test.tsx` had a second offender alongside the known one. Inlined `render()` + `buildWrapper()` into every test they touched; where that inlining left sibling tests rendering identical arguments, moved the shared setup into a `beforeEach` rather than duplicating it, while tests whose render() arguments genuinely differ per test (success vs. error mock responses) stayed inlined.

## Test plan
- I added valid/invalid cases to the rule's test suite covering module scope, top-level describe scope, nested describe scope, a call nested as an argument inside another call, and the additional control-flow shapes (if/else, ternary, logical `&&`, try/catch, intermediate variable, and a nested-closure case that should stay unflagged).
- I ran `yarn lint --quiet`, `yarn typecheck`, and `yarn test` — all pass with zero lint errors and all 1568 tests green.