### PR TITLE
fix(go): stamp SourcePipelineType label unconditionally on PipelineRun create

### DIFF
--- a/go/components/pipelinerun/apihook/apihook.go
+++ b/go/components/pipelinerun/apihook/apihook.go
@@ -93,9 +93,7 @@ func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRun
 			zap.Int("count", len(pipeline.Spec.Notifications)))
 	}
 
-	if pipelineType := pipeline.Spec.GetType(); pipelineType != v2.PIPELINE_TYPE_INVALID {
-		api.StampSourcePipelineTypeLabelOnCreate(request.PipelineRun, pipelineType.String())
-	}
+	api.StampSourcePipelineTypeLabelOnCreate(request.PipelineRun, pipeline.Spec.GetType().String())
 
 	return cascadedelete.StampOwnerRefOnCreate(ctx, a.logger, a.scheme, request.PipelineRun, pipeline)
 }

--- a/go/components/pipelinerun/apihook/apihook_test.go
+++ b/go/components/pipelinerun/apihook/apihook_test.go
@@ -629,3 +629,21 @@ func TestBeforeCreate_StampsSourcePipelineTypeLabel(t *testing.T) {
 	assert.Equal(t, "PIPELINE_TYPE_TRAIN",
 		request.PipelineRun.GetLabels()[api.SourcePipelineTypeLabelName])
 }
+
+// When the owning Pipeline has no type set (proto3 zero value
+// PIPELINE_TYPE_INVALID), the label must still be stamped with the
+// explicit string "PIPELINE_TYPE_INVALID" rather than silently omitted.
+// This provides a greppable diagnostic value on every PipelineRun.
+func TestBeforeCreate_StampsSourcePipelineTypeLabelWhenTypeUnset(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+		// Spec.Type deliberately omitted — defaults to PIPELINE_TYPE_INVALID (0).
+	}
+	hook := setUpHook(t, live)
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	assert.Equal(t, "PIPELINE_TYPE_INVALID",
+		request.PipelineRun.GetLabels()[api.SourcePipelineTypeLabelName],
+		"label must be present even when the Pipeline has no type set")
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Removed the `PIPELINE_TYPE_INVALID` guard in `go/components/pipelinerun/apihook/apihook.go`'s `BeforeCreate` so that the `michelangelo/SourcePipelineType` label is stamped on every PipelineRun unconditionally. When a Pipeline has no `Spec.Type` set (the proto3 zero value), the label value is now the explicit string `"PIPELINE_TYPE_INVALID"` instead of being silently omitted.

Added a test case covering the previously-untested path where the owning Pipeline has no type set.

**Why?**

When a Pipeline's type is unset, the previous guard caused PipelineRuns created against it to have no `SourcePipelineType` label at all. This made it difficult to diagnose why PhaseEntityView's server-side type filters (`labelSelector: michelangelo/SourcePipelineType in (PIPELINE_TYPE_TRAIN, PIPELINE_TYPE_EVAL)`) returned zero results — the absence left no trace on the PipelineRun itself, requiring cross-referencing the owning Pipeline in the database.

An explicit `"PIPELINE_TYPE_INVALID"` label value is immediately greppable and tells an investigator the source Pipeline had no type configured. Note: this does not fix the underlying filter-visibility issue (a filter for `PIPELINE_TYPE_TRAIN` still won't match `PIPELINE_TYPE_INVALID`), only restores an always-present diagnostic label. Fixing the root cause (validating or defaulting `Pipeline.Spec.Type` at create time) is a separate, larger design decision deferred for a follow-up.

**How did you test it?**

- Added `TestBeforeCreate_StampsSourcePipelineTypeLabelWhenTypeUnset` — creates a Pipeline with no `Spec.Type` set and asserts the resulting PipelineRun carries `SourcePipelineType=PIPELINE_TYPE_INVALID`.
- Existing `TestBeforeCreate_StampsSourcePipelineTypeLabel` (PIPELINE_TYPE_TRAIN path) continues to pass.
- `go test ./components/pipelinerun/apihook/...` — all tests pass.

**Potential risks**

Low. PipelineRuns against untyped Pipelines previously had no `SourcePipelineType` label; they will now have `PIPELINE_TYPE_INVALID`. No existing filter matches that value, so no behavior changes for queries that filter on specific valid types.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

N/A