### PR TITLE
feat(examples): package and push the fine-tuned bert_cola model

### DIFF
--- a/python/examples/bert_cola/README.md
+++ b/python/examples/bert_cola/README.md
@@ -35,7 +35,7 @@ push results: [PusherResult(name='model', plugin='model_plugin', success=True, .
 ok.
 ```
 
-After training, `package_model` packages the fine-tuned checkpoint into a
+After training, `assembler` packages the fine-tuned checkpoint into a
 deployable Triton package + a raw package (via the custom, Python-backend
 assembler path -- BERT's multi-input `forward()` isn't TorchScript-friendly),
 and `push_step` registers it in a model registry (`InMemoryRegistryClient` by

--- a/python/examples/bert_cola/README.md
+++ b/python/examples/bert_cola/README.md
@@ -29,6 +29,15 @@ Training BERT model...
 Epoch 1/3: loss=0.512, accuracy=0.85
 Epoch 2/3: loss=0.312, accuracy=0.89
 Epoch 3/3: loss=0.201, accuracy=0.92
-result: {'model_path': '/tmp/bert_cola_model', 'metrics': {...}}
+train_result: TrainOutput(...)
+assembled model: AssembledModel(raw_model=..., deployable_model=...)
+push results: [PusherResult(name='model', plugin='model_plugin', success=True, ...)]
 ok.
 ```
+
+After training, `package_model` packages the fine-tuned checkpoint into a
+deployable Triton package + a raw package (via the custom, Python-backend
+assembler path -- BERT's multi-input `forward()` isn't TorchScript-friendly),
+and `push_step` registers it in a model registry (`InMemoryRegistryClient` by
+default; set `REGISTRY_ENDPOINT` for a real registry). Set `AWS_ENDPOINT_URL`
+to push to MinIO/S3-compatible storage instead of a local temp directory.

--- a/python/examples/bert_cola/assembler.py
+++ b/python/examples/bert_cola/assembler.py
@@ -1,4 +1,4 @@
-"""Packaging task for the BERT CoLA fine-tuning workflow.
+"""Assembler step for the BERT CoLA fine-tuning workflow.
 
 Turns the locally-saved HuggingFace checkpoint from ``train()`` into a
 deployable + raw Triton package via ``custom_assembler`` (the Python-backend
@@ -36,7 +36,7 @@ from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
 
 log = logging.getLogger(__name__)
 
-__all__ = ["package_model"]
+__all__ = ["assembler"]
 
 _MODEL_CLASS = "examples.bert_cola.model.BertColaModel"
 _TOKENIZER_NAME = "bert-base-cased"
@@ -74,7 +74,7 @@ def _resolve_storage_backend(tmp_prefix: str):
             create_bucket_if_missing=True,
         )
         log.info(
-            "package_model: using MinioStorageBackend (remote) -> %s",
+            "assembler: using MinioStorageBackend (remote) -> %s",
             storage_backend.get_storage_location(),
         )
         return storage_backend
@@ -83,7 +83,7 @@ def _resolve_storage_backend(tmp_prefix: str):
 
     local_dir = tempfile.mkdtemp(prefix=tmp_prefix)
     storage_backend = LocalStorageBackend(local_dir)
-    log.info("package_model: using LocalStorageBackend (local/CI) -> %s", local_dir)
+    log.info("assembler: using LocalStorageBackend (local/CI) -> %s", local_dir)
     return storage_backend
 
 
@@ -124,13 +124,13 @@ def _sample_data(
 @uniflow.task(
     config=RayTask(head_cpu=1, head_memory="2Gi", worker_instances=0),
 )
-def package_model(
+def assembler(
     train_output_dir: str,
     lr: float,
     eps: float,
     tokenizer_max_length: int = 128,
 ) -> AssembledModel:
-    """Package the fine-tuned BERT checkpoint into deployable and raw Triton packages.
+    """Assemble the fine-tuned BERT checkpoint into deployable and raw Triton packages.
 
     ``CustomTritonPackager`` (invoked via ``custom_assembler``) only
     understands locally-resident model artifacts, and the raw checkpoint is
@@ -150,7 +150,7 @@ def package_model(
     Returns:
         ``AssembledModel`` with the deployable and raw packaged artifacts.
     """
-    storage_backend = _resolve_storage_backend("bert_cola_package_")
+    storage_backend = _resolve_storage_backend("bert_cola_assembler_")
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(_TOKENIZER_NAME)
     schema = _schema(tokenizer_max_length)
@@ -174,7 +174,7 @@ def package_model(
         storage_backend=storage_backend,
     )
     log.info(
-        "package_model: deployable=%s raw=%s",
+        "assembler: deployable=%s raw=%s",
         assembled.deployable_model.path,
         assembled.raw_model.path,
     )

--- a/python/examples/bert_cola/bert_cola.py
+++ b/python/examples/bert_cola/bert_cola.py
@@ -7,6 +7,8 @@ Support workflow parameters via dict or Starlark-compatible parameters.
 
 import michelangelo.uniflow.core as uniflow
 from examples.bert_cola.data import load_data
+from examples.bert_cola.package import package_model
+from examples.bert_cola.push import push_step
 from examples.bert_cola.train import train
 from michelangelo.uniflow.plugins.ray import UF_PLUGIN_RAY_USE_FSSPEC
 
@@ -24,12 +26,25 @@ def train_workflow(path="nyu-mll/glue", name="cola", tokenizer_max_length=128):
         name=name,
         tokenizer_max_length=tokenizer_max_length,
     )
-    result = train(
+    train_result, output_dir = train(
         train_data,
         validation_data,
         test_data,
     )
-    print("result:", result)
+    print("train_result:", train_result)
+
+    assembled = package_model(
+        output_dir,
+        # Must match train.py's hardcoded lr/eps -- train() doesn't return
+        # them, since they're training config, not a training result.
+        lr=2e-5,
+        eps=1e-8,
+        tokenizer_max_length=tokenizer_max_length,
+    )
+    print("assembled model:", assembled)
+
+    push_results = push_step(assembled)
+    print("push results:", push_results)
     print("ok.")
 
 

--- a/python/examples/bert_cola/bert_cola.py
+++ b/python/examples/bert_cola/bert_cola.py
@@ -35,8 +35,7 @@ def train_workflow(path="nyu-mll/glue", name="cola", tokenizer_max_length=128):
 
     assembled = package_model(
         output_dir,
-        # Must match train.py's hardcoded lr/eps -- train() doesn't return
-        # them, since they're training config, not a training result.
+        # Must match train.py's hardcoded lr/eps.
         lr=2e-5,
         eps=1e-8,
         tokenizer_max_length=tokenizer_max_length,

--- a/python/examples/bert_cola/bert_cola.py
+++ b/python/examples/bert_cola/bert_cola.py
@@ -6,8 +6,8 @@ Support workflow parameters via dict or Starlark-compatible parameters.
 """
 
 import michelangelo.uniflow.core as uniflow
+from examples.bert_cola.assembler import assembler
 from examples.bert_cola.data import load_data
-from examples.bert_cola.package import package_model
 from examples.bert_cola.push import push_step
 from examples.bert_cola.train import train
 from michelangelo.uniflow.plugins.ray import UF_PLUGIN_RAY_USE_FSSPEC
@@ -33,7 +33,7 @@ def train_workflow(path="nyu-mll/glue", name="cola", tokenizer_max_length=128):
     )
     print("train_result:", train_result)
 
-    assembled = package_model(
+    assembled = assembler(
         output_dir,
         # Must match train.py's hardcoded lr/eps.
         lr=2e-5,

--- a/python/examples/bert_cola/model.py
+++ b/python/examples/bert_cola/model.py
@@ -4,10 +4,9 @@ Wraps a HuggingFace ``AutoModelForSequenceClassification`` + tokenizer as a
 ``michelangelo.lib.model_manager.interface.custom_model.Model`` so it can be
 packaged via ``CustomTritonPackager``/``custom_assembler``. BERT takes
 multiple named tensor inputs (``input_ids``, ``attention_mask``,
-``token_type_ids``), which isn't a good TorchScript-tracing fit -- the custom
-(Python-backend) path avoids tracing entirely and just calls the HF model
-directly in ``predict()``, mirroring
-``examples.model_manager.simple_custom.model.DummyEchoModel``.
+``token_type_ids``), which isn't a good TorchScript-tracing fit, so this
+avoids tracing entirely and just calls the HF model directly in
+``predict()``.
 """
 
 from __future__ import annotations
@@ -43,12 +42,7 @@ class BertColaModel(Model):
         self._model.eval()
 
     def save(self, path: str) -> None:
-        """Persist the model and tokenizer under ``path`` via HF's own format.
-
-        Uses ``save_pretrained()`` rather than ``torch.save``/pickle, per the
-        ``Model.save()`` contract's guidance to prefer format-specific
-        serialization.
-        """
+        """Persist the model and tokenizer under ``path`` via HF's own format."""
         self._model.save_pretrained(path)
         self._tokenizer.save_pretrained(path)
 

--- a/python/examples/bert_cola/model.py
+++ b/python/examples/bert_cola/model.py
@@ -20,8 +20,6 @@ from michelangelo.lib.model_manager.interface.custom_model import Model
 
 __all__ = ["BertColaModel"]
 
-_PRETRAINED_MODEL_NAME = "bert-base-cased"
-
 
 class BertColaModel(Model):
     """Fine-tuned BERT sequence classifier for the CoLA linguistic-acceptability task.

--- a/python/examples/bert_cola/model.py
+++ b/python/examples/bert_cola/model.py
@@ -1,0 +1,73 @@
+"""Custom Model Manager wrapper for the fine-tuned BERT CoLA classifier.
+
+Wraps a HuggingFace ``AutoModelForSequenceClassification`` + tokenizer as a
+``michelangelo.lib.model_manager.interface.custom_model.Model`` so it can be
+packaged via ``CustomTritonPackager``/``custom_assembler``. BERT takes
+multiple named tensor inputs (``input_ids``, ``attention_mask``,
+``token_type_ids``), which isn't a good TorchScript-tracing fit -- the custom
+(Python-backend) path avoids tracing entirely and just calls the HF model
+directly in ``predict()``, mirroring
+``examples.model_manager.simple_custom.model.DummyEchoModel``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import transformers
+
+from michelangelo.lib.model_manager.interface.custom_model import Model
+
+__all__ = ["BertColaModel"]
+
+_PRETRAINED_MODEL_NAME = "bert-base-cased"
+
+
+class BertColaModel(Model):
+    """Fine-tuned BERT sequence classifier for the CoLA linguistic-acceptability task.
+
+    - **Inputs** (each an int64 array of shape ``[tokenizer_max_length]``):
+      - input_ids
+      - attention_mask
+      - token_type_ids
+    - **Outputs**:
+      - logits: float32 ``[2]`` (one score per CoLA label)
+    """
+
+    def __init__(
+        self,
+        model: transformers.PreTrainedModel,
+        tokenizer: transformers.PreTrainedTokenizerBase,
+    ) -> None:
+        """Wrap an already-loaded model and tokenizer."""
+        self._model = model
+        self._tokenizer = tokenizer
+        self._model.eval()
+
+    def save(self, path: str) -> None:
+        """Persist the model and tokenizer under ``path`` via HF's own format.
+
+        Uses ``save_pretrained()`` rather than ``torch.save``/pickle, per the
+        ``Model.save()`` contract's guidance to prefer format-specific
+        serialization.
+        """
+        self._model.save_pretrained(path)
+        self._tokenizer.save_pretrained(path)
+
+    @classmethod
+    def load(cls, path: str) -> BertColaModel:
+        """Load the model and tokenizer from ``path``."""
+        model = transformers.AutoModelForSequenceClassification.from_pretrained(path)
+        tokenizer = transformers.AutoTokenizer.from_pretrained(path)
+        return cls(model, tokenizer)
+
+    def predict(self, inputs: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Run the classifier on tokenized inputs, returning per-class logits."""
+        with torch.no_grad():
+            model_inputs = {
+                name: torch.as_tensor(inputs[name], dtype=torch.long).unsqueeze(0)
+                for name in ("input_ids", "attention_mask", "token_type_ids")
+                if name in inputs
+            }
+            logits = self._model(**model_inputs).logits.squeeze(0)
+        return {"logits": logits.numpy().astype(np.float32)}

--- a/python/examples/bert_cola/package.py
+++ b/python/examples/bert_cola/package.py
@@ -43,11 +43,10 @@ _TOKENIZER_NAME = "bert-base-cased"
 
 
 def _resolve_storage_backend(tmp_prefix: str):
-    """Select MinIO (remote) or a local temp directory.
+    """Select a storage backend based on environment configuration.
 
-    Mirrors ``examples.pipelines.california_housing_xgb.push.push_step``'s
-    backend selection: ``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible remote
-    storage; unset -> a local temp directory (development and CI).
+    ``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible remote storage; unset ->
+    a local temp directory (development and CI).
     """
     s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
     if s3_endpoint:

--- a/python/examples/bert_cola/package.py
+++ b/python/examples/bert_cola/package.py
@@ -1,0 +1,182 @@
+"""Packaging task for the BERT CoLA fine-tuning workflow.
+
+Turns the locally-saved HuggingFace checkpoint from ``train()`` into a
+deployable + raw Triton package via ``custom_assembler`` (the Python-backend
+assembler path -- BERT's multi-input ``forward()`` isn't a good TorchScript
+fit, so this doesn't use ``torch_assembler``).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import os
+import pickle
+import tempfile
+from urllib.parse import urlparse
+
+import numpy as np
+import transformers
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.lib.model_manager.schema import DataType, ModelSchema, ModelSchemaItem
+from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.workflow.schema.assembler import (
+    CustomAssemblerConfig,
+    TabularAssemblerConfig,
+)
+from michelangelo.workflow.tasks.tabular_assembler.custom.assembler import (
+    custom_assembler,
+)
+from michelangelo.workflow.variables.metadata import (
+    TRAINING_FRAMEWORK_CUSTOM,
+    ModelMetadata,
+)
+from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
+
+log = logging.getLogger(__name__)
+
+__all__ = ["package_model"]
+
+_MODEL_CLASS = "examples.bert_cola.model.BertColaModel"
+_TOKENIZER_NAME = "bert-base-cased"
+
+
+def _resolve_storage_backend(tmp_prefix: str):
+    """Select MinIO (remote) or a local temp directory.
+
+    Mirrors ``examples.pipelines.california_housing_xgb.push.push_step``'s
+    backend selection: ``AWS_ENDPOINT_URL`` set -> MinIO/S3-compatible remote
+    storage; unset -> a local temp directory (development and CI).
+    """
+    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if s3_endpoint:
+        parsed = urlparse(s3_endpoint)
+        endpoint = parsed.netloc
+        if not endpoint:
+            raise ValueError(
+                f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
+                "Use a full URL like http://minio:9091"
+            )
+        bucket = (
+            os.environ.get("AWS_S3_BUCKET")
+            or os.environ.get("MA_FILE_SYSTEM", "s3://default")
+            .removeprefix("s3://")
+            .split("/")[0]
+        )
+        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+
+        storage_backend = MinioStorageBackend(
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+            secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+            secure=parsed.scheme == "https",
+            create_bucket_if_missing=True,
+        )
+        log.info(
+            "package_model: using MinioStorageBackend (remote) -> %s",
+            storage_backend.get_storage_location(),
+        )
+        return storage_backend
+
+    from michelangelo.lib.artifact_manager.storage_backend import LocalStorageBackend
+
+    local_dir = tempfile.mkdtemp(prefix=tmp_prefix)
+    storage_backend = LocalStorageBackend(local_dir)
+    log.info("package_model: using LocalStorageBackend (local/CI) -> %s", local_dir)
+    return storage_backend
+
+
+def _schema(tokenizer_max_length: int) -> ModelSchema:
+    token_fields = ["input_ids", "attention_mask", "token_type_ids"]
+    return ModelSchema(
+        input_schema=[
+            ModelSchemaItem(
+                name=name, data_type=DataType.LONG, shape=[tokenizer_max_length]
+            )
+            for name in token_fields
+        ],
+        output_schema=[
+            ModelSchemaItem(name="logits", data_type=DataType.FLOAT, shape=[2]),
+        ],
+    )
+
+
+def _sample_data(
+    tokenizer: transformers.PreTrainedTokenizerBase, tokenizer_max_length: int
+) -> list[dict[str, np.ndarray]]:
+    encoded = tokenizer(
+        "This sentence is grammatically acceptable.",
+        max_length=tokenizer_max_length,
+        truncation=True,
+        padding="max_length",
+        return_tensors="np",
+    )
+    return [
+        {
+            "input_ids": encoded["input_ids"][0].astype(np.int64),
+            "attention_mask": encoded["attention_mask"][0].astype(np.int64),
+            "token_type_ids": encoded["token_type_ids"][0].astype(np.int64),
+        }
+    ]
+
+
+@uniflow.task(
+    config=RayTask(head_cpu=1, head_memory="2Gi", worker_instances=0),
+)
+def package_model(
+    train_output_dir: str,
+    lr: float,
+    eps: float,
+    tokenizer_max_length: int = 128,
+) -> AssembledModel:
+    """Package the fine-tuned BERT checkpoint into deployable and raw Triton packages.
+
+    ``CustomTritonPackager`` (invoked via ``custom_assembler``) only
+    understands locally-resident model artifacts, and the raw checkpoint is
+    already local (``train()`` writes it via ``trainer.save_model()``), so
+    this uploads it once through this task's own storage backend to obtain a
+    URI ``custom_assembler`` can download back from.
+
+    Args:
+        train_output_dir: Local directory ``train()`` saved the fine-tuned
+            model and tokenizer to (via ``Trainer.save_model()``).
+        lr: Learning rate used for training, recorded as a hyperparameter.
+        eps: Adam epsilon used for training, recorded as a hyperparameter.
+        tokenizer_max_length: Max sequence length used for tokenization --
+            determines the packaged schema's input shape and must match what
+            ``load_data()`` used.
+
+    Returns:
+        ``AssembledModel`` with the deployable and raw packaged artifacts.
+    """
+    storage_backend = _resolve_storage_backend("bert_cola_package_")
+
+    tokenizer = transformers.AutoTokenizer.from_pretrained(_TOKENIZER_NAME)
+    schema = _schema(tokenizer_max_length)
+    sample_data = _sample_data(tokenizer, tokenizer_max_length)
+
+    raw_model_uri = storage_backend.upload(train_output_dir, "raw_model")
+    metadata = ModelMetadata(
+        training_framework=TRAINING_FRAMEWORK_CUSTOM,
+        model_class=_MODEL_CLASS,
+        _schema=io.BytesIO(pickle.dumps(schema)),
+        _sample_data=io.BytesIO(pickle.dumps(sample_data)),
+    )
+    metadata.hyperparameters = {"lr": lr, "eps": eps}
+    raw_model = ModelArtifact(path=raw_model_uri, metadata=metadata)
+
+    assembled = custom_assembler(
+        TabularAssemblerConfig(
+            custom=CustomAssemblerConfig(include_import_prefixes=["examples.bert_cola"])
+        ),
+        raw_model,
+        storage_backend=storage_backend,
+    )
+    log.info(
+        "package_model: deployable=%s raw=%s",
+        assembled.deployable_model.path,
+        assembled.raw_model.path,
+    )
+    return assembled

--- a/python/examples/bert_cola/push.py
+++ b/python/examples/bert_cola/push.py
@@ -1,0 +1,157 @@
+"""Pusher step for the BERT CoLA fine-tuning workflow.
+
+Registers the assembled model (produced by ``package_model``) in a model
+registry via ``ModelPusherPlugin``. Constructs its own storage backend and
+registry client, independently of ``package.py`` -- uniflow tasks can't
+share live objects across the workflow boundary (same reasoning documented
+in ``examples.pipelines.california_housing_xgb.push.push_step``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from urllib.parse import urlparse
+
+import michelangelo.uniflow.core as uniflow
+from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.workflow.schema.pusher import (
+    ModelPluginConfig,
+    PusherConfig,
+    PusherPluginConfig,
+)
+from michelangelo.workflow.tasks.pusher import push
+
+# Kept top-level (not TYPE_CHECKING) despite only being used in annotations --
+# uniflow's @uniflow.task needs these resolvable as real objects at the
+# workflow boundary, matching
+# examples.pipelines.california_housing_xgb.push.push_step's same choice.
+from michelangelo.workflow.variables.types import (  # noqa: TC001
+    AssembledModel,
+    PusherResult,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = ["push_step"]
+
+
+@uniflow.task(
+    config=RayTask(head_cpu=1, head_memory="1Gi", worker_instances=0),
+)
+def push_step(assembled: AssembledModel) -> list[PusherResult]:
+    """Push the assembled BERT CoLA model to storage and the model registry.
+
+    Args:
+        assembled: Result of ``package_model`` -- deployable and raw Triton
+            packages for the fine-tuned classifier.
+
+    Returns:
+        List of ``PusherResult``, one per artifact pushed (just ``model`` here).
+    """
+    s3_endpoint = os.environ.get("AWS_ENDPOINT_URL", "")
+    if s3_endpoint:
+        parsed = urlparse(s3_endpoint)
+        endpoint = parsed.netloc
+        if not endpoint:
+            raise ValueError(
+                f"AWS_ENDPOINT_URL={s3_endpoint!r} is missing a scheme. "
+                "Use a full URL like http://minio:9091"
+            )
+        bucket = (
+            os.environ.get("AWS_S3_BUCKET")
+            or os.environ.get("MA_FILE_SYSTEM", "s3://default")
+            .removeprefix("s3://")
+            .split("/")[0]
+        )
+        from michelangelo.lib.artifact_manager.minio_backend import MinioStorageBackend
+
+        storage_backend = MinioStorageBackend(
+            endpoint=endpoint,
+            bucket=bucket,
+            access_key=os.environ.get("AWS_ACCESS_KEY_ID", ""),
+            secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY", ""),
+            secure=parsed.scheme == "https",
+            create_bucket_if_missing=True,
+        )
+        log.info(
+            "push_step: using MinioStorageBackend (remote) -> %s",
+            storage_backend.get_storage_location(),
+        )
+    else:
+        import tempfile
+
+        from michelangelo.lib.artifact_manager.storage_backend import (
+            LocalStorageBackend,
+        )
+
+        local_dir = tempfile.mkdtemp(prefix="bert_cola_push_")
+        storage_backend = LocalStorageBackend(local_dir)
+        log.info("push_step: using LocalStorageBackend (local/CI) -> %s", local_dir)
+
+    registry_endpoint = os.environ.get("REGISTRY_ENDPOINT")
+    if registry_endpoint:
+        import grpc as _grpc
+
+        from michelangelo.api.v2 import APIClient
+        from michelangelo.lib.model_manager.registry.api_client import (
+            APIRegistryClient,
+        )
+
+        _insecure = os.environ.get("REGISTRY_INSECURE", "true").lower() != "false"
+        _credentials = None if _insecure else _grpc.ssl_channel_credentials()
+        _channel = (
+            _grpc.insecure_channel(registry_endpoint)
+            if _insecure
+            else _grpc.secure_channel(registry_endpoint, _credentials)
+        )
+        _api_client = APIClient(caller="bert-cola-push-step", channel=_channel)
+        registry_client = APIRegistryClient(
+            svc=_api_client.ModelService,
+            namespace=os.environ.get(
+                "REGISTRY_NAMESPACE", os.environ.get("MA_NAMESPACE", "default")
+            ),
+        )
+        log.info("push_step: using APIRegistryClient at %s", registry_endpoint)
+    else:
+        from michelangelo.lib.model_manager.registry.client import (
+            InMemoryRegistryClient,
+        )
+
+        registry_client = InMemoryRegistryClient()
+        log.warning(
+            "REGISTRY_ENDPOINT not set -- using InMemoryRegistryClient. "
+            "Model registration will not be persisted."
+        )
+
+    config = PusherConfig(
+        items=[
+            PusherPluginConfig(
+                name="model",
+                model_plugin=ModelPluginConfig(
+                    model_name="bert-cola",
+                    description="BERT fine-tuned for CoLA linguistic acceptability",
+                    labels={"framework": "transformers"},
+                ),
+            ),
+        ]
+    )
+
+    results = push(
+        config=config,
+        artifacts={"model": assembled},
+        storage_backend=storage_backend,
+        registry_client=registry_client,
+    )
+
+    for r in results:
+        log.info(
+            "push %s (%s): success=%s value=%s error=%s",
+            r.name,
+            r.plugin,
+            r.success,
+            r.value,
+            r.error,
+        )
+
+    return results

--- a/python/examples/bert_cola/push.py
+++ b/python/examples/bert_cola/push.py
@@ -3,8 +3,7 @@
 Registers the assembled model (produced by ``package_model``) in a model
 registry via ``ModelPusherPlugin``. Constructs its own storage backend and
 registry client, independently of ``package.py`` -- uniflow tasks can't
-share live objects across the workflow boundary (same reasoning documented
-in ``examples.pipelines.california_housing_xgb.push.push_step``).
+share live objects across the workflow boundary.
 """
 
 from __future__ import annotations
@@ -24,8 +23,7 @@ from michelangelo.workflow.tasks.pusher import push
 
 # Kept top-level (not TYPE_CHECKING) despite only being used in annotations --
 # uniflow's @uniflow.task needs these resolvable as real objects at the
-# workflow boundary, matching
-# examples.pipelines.california_housing_xgb.push.push_step's same choice.
+# workflow boundary.
 from michelangelo.workflow.variables.types import (  # noqa: TC001
     AssembledModel,
     PusherResult,
@@ -131,6 +129,7 @@ def push_step(assembled: AssembledModel) -> list[PusherResult]:
                 model_plugin=ModelPluginConfig(
                     description="BERT fine-tuned for CoLA linguistic acceptability",
                     labels={"framework": "transformers"},
+                    tar_deployable_package=True,
                 ),
             ),
         ]

--- a/python/examples/bert_cola/push.py
+++ b/python/examples/bert_cola/push.py
@@ -1,8 +1,8 @@
 """Pusher step for the BERT CoLA fine-tuning workflow.
 
-Registers the assembled model (produced by ``package_model``) in a model
+Registers the assembled model (produced by ``assembler``) in a model
 registry via ``ModelPusherPlugin``. Constructs its own storage backend and
-registry client, independently of ``package.py`` -- uniflow tasks can't
+registry client, independently of ``assembler.py`` -- uniflow tasks can't
 share live objects across the workflow boundary.
 """
 
@@ -41,7 +41,7 @@ def push_step(assembled: AssembledModel) -> list[PusherResult]:
     """Push the assembled BERT CoLA model to storage and the model registry.
 
     Args:
-        assembled: Result of ``package_model`` -- deployable and raw Triton
+        assembled: Result of ``assembler`` -- deployable and raw Triton
             packages for the fine-tuned classifier.
 
     Returns:

--- a/python/examples/bert_cola/push.py
+++ b/python/examples/bert_cola/push.py
@@ -129,7 +129,6 @@ def push_step(assembled: AssembledModel) -> list[PusherResult]:
             PusherPluginConfig(
                 name="model",
                 model_plugin=ModelPluginConfig(
-                    model_name="bert-cola",
                     description="BERT fine-tuned for CoLA linguistic acceptability",
                     labels={"framework": "transformers"},
                 ),

--- a/python/examples/bert_cola/train.py
+++ b/python/examples/bert_cola/train.py
@@ -58,7 +58,10 @@ def train(
         test_data: Ray Dataset containing test examples.
 
     Returns:
-        Dictionary containing training metrics and model save path.
+        Tuple of ``(train_result, output_dir)``: the HuggingFace
+        ``TrainOutput`` from ``trainer.train()``, and the local directory the
+        fine-tuned model and tokenizer were saved to via
+        ``trainer.save_model()``.
     """
     log.info("Starting training...")
 
@@ -104,13 +107,9 @@ def train(
     train_result = trainer.train()
     trainer.save_model(output_dir)
 
-    log.info("Training complete. Best model saved.")
+    log.info("Training complete. Best model saved to %s.", output_dir)
 
-    # Get the best checkpoint path
-    best_checkpoint = training_args.output_dir + "/checkpoint-best"
-    log.info(f"Best checkpoint path: {best_checkpoint}")
-
-    return train_result, best_checkpoint
+    return train_result, output_dir
 
 
 def _compute_metrics(eval_pred):


### PR DESCRIPTION
**TL;DR:** Adds a packaging + push step to the `bert_cola` example, so finishing a training run leaves you with an actual deployable, registered model instead of just a local checkpoint.

## Summary

- **`model.py`** — `BertColaModel(Model)`, wrapping the HF model + tokenizer for `CustomTritonPackager`. Uses the custom (Python-backend) assembler path rather than `torch_assembler`, since BERT's multi-input `forward()` (`input_ids`/`attention_mask`/`token_type_ids`) isn't a good TorchScript-tracing fit.
- **`assembler.py`** — new `assembler` task: uploads the trained checkpoint through a storage backend, builds the `ModelSchema`/sample data for the tokenized input/logits shapes, and calls `custom_assembler()` to produce deployable + raw Triton packages.
- **`push.py`** — new `push_step` task: registers the assembled model via `ModelPusherPlugin`. Storage backend resolves from `AWS_ENDPOINT_URL` (MinIO/S3 if set, else a local temp dir); registry client resolves from `REGISTRY_ENDPOINT` (a real registry if set, else in-memory). `model_name` is left unset so the pusher auto-generates a unique name per push, and `tar_deployable_package=True` so the deployable package is pushed as a single tarball.
- **`train.py`** — fixed the return path: `trainer.save_model(output_dir)` writes directly to `output_dir`, not a `checkpoint-best` subdirectory, so `train()` now returns the real save path for `assembler` to use.
- **`bert_cola.py`** — wires `assembler` and `push_step` into the workflow after `train()`.

## Test plan
- [x] Ran the full workflow locally end-to-end with a local storage backend and in-memory registry: training, packaging, and push all complete, producing a valid deployable Triton package (`config.pbtxt`, versioned model dir, HF weights/tokenizer) and a successful `PusherResult`.
- [x] Ran the full workflow against a real MinIO instance and confirmed the pushed artifacts (raw + deployable, under an auto-generated model name) actually land in the bucket.
- [x] `ruff format` / `ruff check` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
