### PR TITLE
fix(examples/bert_cola): pass the trained model as a ModelVariable, not a local path

### DIFF
--- a/python/examples/bert_cola/assembler.py
+++ b/python/examples/bert_cola/assembler.py
@@ -1,6 +1,6 @@
 """Assembler step for the BERT CoLA fine-tuning workflow.
 
-Turns the locally-saved HuggingFace checkpoint from ``train()`` into a
+Turns the trained checkpoint from ``train()`` (a ``ModelVariable``) into a
 deployable + raw Triton package via ``custom_assembler`` (the Python-backend
 assembler path -- BERT's multi-input ``forward()`` isn't a good TorchScript
 fit, so this doesn't use ``torch_assembler``).
@@ -13,8 +13,10 @@ import logging
 import os
 import pickle
 import tempfile
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+import fsspec
 import numpy as np
 import transformers
 
@@ -34,11 +36,13 @@ from michelangelo.workflow.variables.metadata import (
 )
 from michelangelo.workflow.variables.types import AssembledModel, ModelArtifact
 
+if TYPE_CHECKING:
+    from michelangelo.workflow.variables import ModelVariable
+
 log = logging.getLogger(__name__)
 
 __all__ = ["assembler"]
 
-_MODEL_CLASS = "examples.bert_cola.model.BertColaModel"
 _TOKENIZER_NAME = "bert-base-cased"
 
 
@@ -125,22 +129,20 @@ def _sample_data(
     config=RayTask(head_cpu=1, head_memory="2Gi", worker_instances=0),
 )
 def assembler(
-    train_output_dir: str,
+    model_variable: ModelVariable,
     lr: float,
     eps: float,
     tokenizer_max_length: int = 128,
 ) -> AssembledModel:
     """Assemble the fine-tuned BERT checkpoint into deployable and raw Triton packages.
 
-    ``CustomTritonPackager`` (invoked via ``custom_assembler``) only
-    understands locally-resident model artifacts, and the raw checkpoint is
-    already local (``train()`` writes it via ``trainer.save_model()``), so
-    this uploads it once through this task's own storage backend to obtain a
-    URI ``custom_assembler`` can download back from.
-
     Args:
-        train_output_dir: Local directory ``train()`` saved the fine-tuned
-            model and tokenizer to (via ``Trainer.save_model()``).
+        model_variable: Result of ``train()`` -- a ``ModelVariable`` wrapping
+            the fine-tuned model and tokenizer, persisted under
+            ``UF_STORAGE_URL``. Not yet a ``StorageBackend`` URI
+            ``custom_assembler`` can pull from directly, so this downloads it
+            via the same fsspec mechanism ``ModelVariable`` itself uses, then
+            re-uploads it through this task's own storage backend.
         lr: Learning rate used for training, recorded as a hyperparameter.
         eps: Adam epsilon used for training, recorded as a hyperparameter.
         tokenizer_max_length: Max sequence length used for tokenization --
@@ -156,10 +158,15 @@ def assembler(
     schema = _schema(tokenizer_max_length)
     sample_data = _sample_data(tokenizer, tokenizer_max_length)
 
-    raw_model_uri = storage_backend.upload(train_output_dir, "raw_model")
+    local_dir = tempfile.mkdtemp(prefix="bert_cola_assembler_model_")
+    model_path = os.path.join(local_dir, "model")
+    fs, remote_path = fsspec.core.url_to_fs(model_variable.path)
+    fs.get(remote_path, model_path, recursive=True)
+
+    raw_model_uri = storage_backend.upload(model_path, "raw_model")
     metadata = ModelMetadata(
         training_framework=TRAINING_FRAMEWORK_CUSTOM,
-        model_class=_MODEL_CLASS,
+        model_class=model_variable.metadata.model_class,
         _schema=io.BytesIO(pickle.dumps(schema)),
         _sample_data=io.BytesIO(pickle.dumps(sample_data)),
     )

--- a/python/examples/bert_cola/bert_cola.py
+++ b/python/examples/bert_cola/bert_cola.py
@@ -26,7 +26,7 @@ def train_workflow(path="nyu-mll/glue", name="cola", tokenizer_max_length=128):
         name=name,
         tokenizer_max_length=tokenizer_max_length,
     )
-    train_result, output_dir = train(
+    train_result, model_variable = train(
         train_data,
         validation_data,
         test_data,
@@ -34,7 +34,7 @@ def train_workflow(path="nyu-mll/glue", name="cola", tokenizer_max_length=128):
     print("train_result:", train_result)
 
     assembled = assembler(
-        output_dir,
+        model_variable,
         # Must match train.py's hardcoded lr/eps.
         lr=2e-5,
         eps=1e-8,

--- a/python/examples/bert_cola/train.py
+++ b/python/examples/bert_cola/train.py
@@ -9,7 +9,9 @@ from datasets import Dataset as HFDataset
 from ray.data import Dataset
 
 import michelangelo.uniflow.core as uniflow
+from examples.bert_cola.model import BertColaModel
 from michelangelo.uniflow.plugins.ray import RayTask
+from michelangelo.workflow.variables import ModelVariable
 
 log = logging.getLogger(__name__)
 
@@ -58,10 +60,12 @@ def train(
         test_data: Ray Dataset containing test examples.
 
     Returns:
-        Tuple of ``(train_result, output_dir)``: the HuggingFace
-        ``TrainOutput`` from ``trainer.train()``, and the local directory the
-        fine-tuned model and tokenizer were saved to via
-        ``trainer.save_model()``.
+        Tuple of ``(train_result, model_variable)``: the HuggingFace
+        ``TrainOutput`` from ``trainer.train()``, and a ``ModelVariable``
+        wrapping the fine-tuned model and tokenizer, persisted under
+        ``UF_STORAGE_URL`` -- this task and the ones downstream of it aren't
+        guaranteed to share a filesystem, so the local save path itself
+        isn't returned.
     """
     log.info("Starting training...")
 
@@ -95,21 +99,24 @@ def train(
         load_best_model_at_end=True,
     )
 
+    tokenizer = transformers.AutoTokenizer.from_pretrained("bert-base-cased")
     trainer = transformers.Trainer(
         model=model,
         args=training_args,
         train_dataset=train_data,
         eval_dataset=validation_data,
-        tokenizer=transformers.AutoTokenizer.from_pretrained("bert-base-cased"),
+        tokenizer=tokenizer,
         compute_metrics=_compute_metrics,
     )
 
     train_result = trainer.train()
-    trainer.save_model(output_dir)
 
-    log.info("Training complete. Best model saved to %s.", output_dir)
+    model_variable = ModelVariable.create(BertColaModel(model, tokenizer))
+    model_variable.save()
 
-    return train_result, output_dir
+    log.info("Training complete. Best model uploaded to %s.", model_variable.path)
+
+    return train_result, model_variable
 
 
 def _compute_metrics(eval_pred):


### PR DESCRIPTION
**TL;DR:** Fixes `train()` returning a local filesystem path that `assembler()` isn't guaranteed to have access to.

## Summary

`train()` fine-tunes the model locally, then previously returned the local save directory directly for `assembler()` to read from. That only works if `train()` and `assembler()` happen to execute on the same machine — each is a separate `@uniflow.task`, and a real remote run can schedule them on different pods, in which case the assembler's pod would have no access to the training pod's local disk.

`train()` now wraps the fine-tuned model + tokenizer as a `ModelVariable` (auto-detects the custom training framework since `BertColaModel` implements the `CustomModel` interface, and persists under `UF_STORAGE_URL`) instead of returning a bare local path. `assembler()` downloads it via the same fsspec mechanism `ModelVariable` itself uses, then re-uploads it through its own storage backend before handing it to `custom_assembler()`.

This mirrors how `california_housing`'s `pytorch_train/assembler.py` already handles its Lightning model — the same `ModelVariable` → download → re-upload pattern. As a side effect, this also drops the previously-duplicated `_MODEL_CLASS` constant in `assembler.py`, since `model_variable.metadata.model_class` is set automatically by `ModelVariable.create()`.

## Test plan
- [x] Ran the full workflow end-to-end against a real MinIO instance: `train()` persists the model as a `ModelVariable`, `assembler()` downloads and re-uploads it correctly (with the auto-detected `model_class` intact), and `push_step` completes with `success=True`.
- [x] `ruff format` / `ruff check` — clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
