### PR TITLE
feat(ui): enable the Deploy & Predict phase

### DIFF
--- a/javascript/packages/core/config/phases/deploy.ts
+++ b/javascript/packages/core/config/phases/deploy.ts
@@ -11,7 +11,7 @@ export const DEPLOY_PHASE: PhaseConfig = {
   icon: 'deploy',
   name: 'Deploy & Predict',
   description: 'Deploy your models and predict new data',
-  state: 'comingSoon' as const,
+  state: 'active' as const,
   pipelineTypes: ['PIPELINE_TYPE_PREDICTION', 'PIPELINE_TYPE_SCORER'],
   entities: [
     PIPELINE_ENTITY_CONFIG,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Flips the "Deploy & Predict" phase from `comingSoon` to `active` in
`javascript/packages/core/config/phases/deploy.ts`. This removes the
"Coming soon" badge and enables the phase's tabs (Pipelines, Triggers,
Runs, Targets, Deployments) on the project dashboard.

<!-- Tell your future self why have you made these changes -->
**Why?**

The Deploy & Predict phase was gated behind `state: 'comingSoon'` even
though the underlying work was already complete.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
<img width="1200" height="835" alt="deploy-predict-phase-enabled" src="https://github.com/user-attachments/assets/c63e9604-a0d2-4da7-a98e-e1e551bd1e82" />


**Potential risks**

None. This only changes a UI-level enum on a phase config object; the
entities in this phase were already `active` and fully wired.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A