### PR TITLE
fix: delete recycled TriggerRuns from metadata storage

### DIFF
--- a/go/api/handler/handler_test.go
+++ b/go/api/handler/handler_test.go
@@ -431,6 +431,34 @@ func TestK8sAndMetadataStorage(t *testing.T) {
 	assert.True(t, utils.IsDeleting(&j3))
 }
 
+func TestDeleteMetadataOnlyObjectWithoutBlobStorage(t *testing.T) {
+	k8sClient, err := setupK8s()
+	assert.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	mockMetadataStorage := storagemocks.NewMockMetadataStorage(ctrl)
+	mockMetadataStorage.EXPECT().
+		Delete(gomock.Any(), gomock.Any(), "project01", "recycled-trigger-run").
+		Return(nil).
+		Times(1)
+
+	handler, err := NewAPIHandlerBuilder().
+		WithK8sClient(k8sClient).
+		WithMetadataStorage(mockMetadataStorage, storage.MetadataStorageConfig{EnableMetadataStorage: true}).
+		WithZapLogger(zap.NewNop()).
+		WithMetrics(tally.NoopScope).
+		Build()
+	assert.NoError(t, err)
+
+	err = handler.Delete(context.Background(), &v2pb.TriggerRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "project01",
+			Name:      "recycled-trigger-run",
+		},
+	}, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+}
+
 func TestNewAPIServerHandler(t *testing.T) {
 	err := v2pb.AddToScheme(scheme.Scheme)
 	assert.NoError(t, err)

--- a/go/api/handler/metadata_handler.go
+++ b/go/api/handler/metadata_handler.go
@@ -20,7 +20,7 @@ import (
 // for metadata operations while supporting different storage implementations.
 type MetadataHandlerImpl struct {
 	storage     storage.MetadataStorage
-	blobStorage storage.BlobStorage
+	blobHandler BlobHandler
 	logger      logr.Logger
 }
 
@@ -31,7 +31,7 @@ func NewMetadataHandler(storage storage.MetadataStorage, blobStorage storage.Blo
 	if storage == nil {
 		return &NullMetadataHandler{}
 	}
-	return &MetadataHandlerImpl{storage: storage, blobStorage: blobStorage, logger: logger}
+	return &MetadataHandlerImpl{storage: storage, blobHandler: NewBlobHandler(blobStorage), logger: logger}
 }
 
 // Get implements MetadataHandler.Get by delegating to the storage backend.
@@ -41,7 +41,7 @@ func (m *MetadataHandlerImpl) Get(ctx context.Context, namespace, name string, o
 
 // Update implements MetadataHandler.Update by delegating to the handleUpdate function.
 func (m *MetadataHandlerImpl) Update(ctx context.Context, obj ctrlRTClient.Object) error {
-	return handleUpdate(ctx, obj, m.storage, true, nil, m.blobStorage)
+	return handleUpdate(ctx, obj, m.storage, true, nil, m.blobHandler)
 }
 
 // Delete implements MetadataHandler.Delete by delegating to the handleDelete function.
@@ -50,7 +50,7 @@ func (m *MetadataHandlerImpl) Delete(ctx context.Context, obj ctrlRTClient.Objec
 	if err != nil {
 		return err
 	}
-	return handleDelete(ctx, m.logger, typeMeta, obj, m.storage, m.blobStorage)
+	return handleDelete(ctx, m.logger, typeMeta, obj, m.storage, m.blobHandler)
 }
 
 // List implements MetadataHandler.List by delegating to the storage backend.
@@ -108,7 +108,7 @@ func (n *NullMetadataHandler) List(ctx context.Context, namespace string, opts *
 // handleUpdate is a helper function for updating objects in metadata storage.
 // This function handles the actual update operation by delegating to the storage layer.
 func handleUpdate(ctx context.Context, obj ctrlRTClient.Object, metadataStorage storage.MetadataStorage, direct bool,
-	indexedFields []storage.IndexedField, handler storage.BlobStorage) error {
+	indexedFields []storage.IndexedField, handler BlobHandler) error {
 	// TODO(#555): update the object in blob storage
 	return metadataStorage.Upsert(ctx, obj, direct, indexedFields)
 }
@@ -118,7 +118,7 @@ func handleUpdate(ctx context.Context, obj ctrlRTClient.Object, metadataStorage 
 // 2. Deletes the object in metadataStorage
 // 3. Deletes the object in blob storage
 func handleDelete(ctx context.Context, log logr.Logger, typeMeta *metav1.TypeMeta, object ctrlRTClient.Object,
-	metadataStorage storage.MetadataStorage, handler storage.BlobStorage) error {
+	metadataStorage storage.MetadataStorage, handler BlobHandler) error {
 	if handler.IsObjectInteresting(object) {
 		// TODO(#556): if blob annotations are already available, this Get is not needed
 		getErr := metadataStorage.GetByID(ctx, string(object.GetUID()), object)

--- a/go/api/handler/metadata_handler_test.go
+++ b/go/api/handler/metadata_handler_test.go
@@ -63,7 +63,7 @@ func TestHandleDeleteBlobStorageErrorLogging(t *testing.T) {
 				logLines = append(logLines, args)
 			}, funcr.Options{})
 
-			err := handleDelete(context.Background(), log, typeMeta, obj, metadataStorage, blobStorage)
+			err := handleDelete(context.Background(), log, typeMeta, obj, metadataStorage, NewBlobHandler(blobStorage))
 
 			assert.NoError(t, err)
 			assert.Len(t, logLines, tc.wantErrorLogs)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Use the existing null-safe `BlobHandler` abstraction for metadata operations and add
coverage for deleting a recycled `TriggerRun` that exists only in metadata storage.

<!-- Tell your future self why have you made these changes -->
**Why?**

When blob storage is not configured, deleting a metadata-only object currently calls
`IsObjectInteresting` on a nil blob storage implementation and fails before removing
the object from metadata storage.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- `bazel test //go/api/handler:go_default_test`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Low. Blob-enabled deletion still delegates through the same storage implementation;
the null handler only changes behavior when blob storage is disabled.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

None.

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**

None.
