### PR TITLE
fix(blobstore): construct the GCS client eagerly when a gcs config section is present

### DIFF
--- a/go/base/blobstore/gcs/BUILD.bazel
+++ b/go/base/blobstore/gcs/BUILD.bazel
@@ -23,7 +23,12 @@ go_test(
     srcs = [
         "client_test.go",
         "config_test.go",
+        "module_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@org_uber_go_config//:go_default_library"],
+    deps = [
+        "//go/base/blobstore:go_default_library",
+        "@org_uber_go_config//:go_default_library",
+        "@org_uber_go_fx//:go_default_library",
+    ],
 )

--- a/go/base/blobstore/gcs/client.go
+++ b/go/base/blobstore/gcs/client.go
@@ -18,12 +18,14 @@ var _ blobstore.BlobStoreClient = (*gcsBlobClient)(nil)
 
 // gcsBlobClient is a client for Google Cloud Storage.
 //
-// The underlying storage.Client is created lazily on the first Get call
-// rather than at construction time: storage.NewClient resolves credentials
-// (Application Default Credentials unless configured otherwise) eagerly, so
-// eager construction would fail application startup on deployments that
-// have no GCP credentials and never read gs:// URIs. Lazy construction
-// keeps the gs scheme registered everywhere at no cost to non-GCS users.
+// By default the underlying storage.Client is created lazily on the first
+// Get call rather than at construction time: storage.NewClient resolves
+// credentials (Application Default Credentials unless configured otherwise)
+// eagerly, so eager construction would fail application startup on
+// deployments that have no GCP credentials and never read gs:// URIs. Lazy
+// construction keeps the gs scheme registered everywhere at no cost to
+// non-GCS users. Deployments that declare a gcs config section opt in to
+// eager construction at startup instead (see newClient in module.go).
 type gcsBlobClient struct {
 	config Config
 	scheme string

--- a/go/base/blobstore/gcs/client_test.go
+++ b/go/base/blobstore/gcs/client_test.go
@@ -178,11 +178,47 @@ func TestGcsClient_Get_NotFoundAgainstFake(t *testing.T) {
 }
 
 func TestNewClient_ProvidesBlobStoreClient(t *testing.T) {
-	out := newClient(Config{Anonymous: true})
+	out, err := newClient(Config{Anonymous: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
 	if out.BlobStoreClient == nil {
 		t.Fatal("expected BlobStoreClient to be set, got nil")
 	}
 	if out.BlobStoreClient.Scheme() != "gs" {
 		t.Errorf("expected scheme gs, got %s", out.BlobStoreClient.Scheme())
+	}
+}
+
+func TestNewClient_LazyWithoutConfigSection(t *testing.T) {
+	// Even with a credentials file that cannot be read, construction must
+	// succeed when no gcs config section was declared: the storage client
+	// stays lazy so non-GCS deployments never fail startup.
+	out, err := newClient(Config{CredentialsFile: "/nonexistent/credentials.json"})
+	if err != nil {
+		t.Fatalf("expected no error for lazy construction, got %v", err)
+	}
+	if got := out.BlobStoreClient.(*gcsBlobClient).client; got != nil {
+		t.Error("expected storage client to remain unconstructed, got non-nil")
+	}
+}
+
+func TestNewClient_EagerWithConfigSection(t *testing.T) {
+	out, err := newClient(Config{Anonymous: true, configured: true})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := out.BlobStoreClient.(*gcsBlobClient).client; got == nil {
+		t.Error("expected storage client to be constructed eagerly, got nil")
+	}
+}
+
+func TestNewClient_EagerConstructionFailureSurfacesAtStartup(t *testing.T) {
+	_, err := newClient(Config{CredentialsFile: "/nonexistent/credentials.json", configured: true})
+	if err == nil {
+		t.Fatal("expected eager construction error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create gcs client") {
+		t.Errorf("expected wrapped construction error, got %q", err.Error())
 	}
 }

--- a/go/base/blobstore/gcs/config.go
+++ b/go/base/blobstore/gcs/config.go
@@ -24,10 +24,26 @@ type Config struct {
 	// Anonymous disables authentication. Only useful for public buckets
 	// and emulators.
 	Anonymous bool `yaml:"anonymous"`
+
+	// configured records whether a "gcs" section was present in the
+	// application config at all (even an empty one). Deployments that
+	// declare the section get an eagerly constructed client so that
+	// misconfiguration fails at startup; deployments without it keep
+	// the lazy, zero-cost path. Unexported so it cannot be set from
+	// YAML directly.
+	configured bool
 }
 
 func newConfig(provider config.Provider) (Config, error) {
 	conf := Config{}
-	err := provider.Get(configKey).Populate(&conf)
-	return conf, err
+	value := provider.Get(configKey)
+	if err := value.Populate(&conf); err != nil {
+		return conf, err
+	}
+	// HasValue is deprecated for populating defaults, but it is the only
+	// way to distinguish "gcs section present" (opt in to eager
+	// construction) from "gcs section absent" (stay lazy): an explicit
+	// but empty section still counts as present.
+	conf.configured = value.HasValue()
+	return conf, nil
 }

--- a/go/base/blobstore/gcs/config_test.go
+++ b/go/base/blobstore/gcs/config_test.go
@@ -30,6 +30,9 @@ gcs:
 	if conf.Anonymous {
 		t.Errorf("expected anonymous to be false, got true")
 	}
+	if !conf.configured {
+		t.Error("expected configured to be true when gcs section is present")
+	}
 }
 
 func TestNewConfig_MissingKey(t *testing.T) {
@@ -47,6 +50,32 @@ otherKey:
 	}
 	if conf.CredentialsFile != "" || conf.Endpoint != "" || conf.Anonymous {
 		t.Errorf("expected zero-value config for missing key, got %+v", conf)
+	}
+	if conf.configured {
+		t.Error("expected configured to be false when gcs section is absent")
+	}
+}
+
+func TestNewConfig_EmptySection(t *testing.T) {
+	// A bare "gcs:" key with no fields still declares intent to use GCS
+	// (with Application Default Credentials), so it must count as
+	// configured.
+	yamlContent := `
+gcs:
+`
+	provider, err := config.NewYAMLProviderFromBytes([]byte(yamlContent))
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	conf, err := newConfig(provider)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if conf.CredentialsFile != "" || conf.Endpoint != "" || conf.Anonymous {
+		t.Errorf("expected zero-value fields for empty section, got %+v", conf)
+	}
+	if !conf.configured {
+		t.Error("expected configured to be true for an empty gcs section")
 	}
 }
 
@@ -71,5 +100,48 @@ gcs:
 	}
 	if conf.Anonymous {
 		t.Errorf("expected anonymous to be false, got true")
+	}
+}
+
+func TestConfiguredSectionFailsFastEndToEnd(t *testing.T) {
+	// With a gcs section declared, a broken configuration must surface as
+	// a constructor error (which fails fx application startup) instead of
+	// waiting for the first gs:// read.
+	yamlContent := `
+gcs:
+  credentialsFile: /nonexistent/credentials.json
+`
+	provider, err := config.NewYAMLProviderFromBytes([]byte(yamlContent))
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	conf, err := newConfig(provider)
+	if err != nil {
+		t.Fatalf("expected no config error, got %v", err)
+	}
+	if _, err := newClient(conf); err == nil {
+		t.Fatal("expected eager construction error for broken gcs config, got nil")
+	}
+}
+
+func TestAbsentSectionStaysLazyEndToEnd(t *testing.T) {
+	yamlContent := `
+otherKey:
+  value: something
+`
+	provider, err := config.NewYAMLProviderFromBytes([]byte(yamlContent))
+	if err != nil {
+		t.Fatalf("failed to create provider: %v", err)
+	}
+	conf, err := newConfig(provider)
+	if err != nil {
+		t.Fatalf("expected no config error, got %v", err)
+	}
+	out, err := newClient(conf)
+	if err != nil {
+		t.Fatalf("expected lazy construction to succeed, got %v", err)
+	}
+	if out.BlobStoreClient.(*gcsBlobClient).client != nil {
+		t.Error("expected storage client to remain unconstructed without a gcs section")
 	}
 }

--- a/go/base/blobstore/gcs/module.go
+++ b/go/base/blobstore/gcs/module.go
@@ -18,12 +18,21 @@ var Module = fx.Options(
 	fx.Provide(newClient),
 )
 
-// newClient creates the Google Cloud Storage blob store client. The
-// underlying storage client is constructed lazily on first use (see
-// gcsBlobClient), so providing this module never fails startup for
-// deployments that do not use GCS.
-func newClient(config Config) BlobStoreClientOut {
-	return BlobStoreClientOut{
-		BlobStoreClient: newGcsBlobClient(config),
+// newClient creates the Google Cloud Storage blob store client.
+//
+// When the application config contains a gcs section, the underlying
+// storage client is constructed immediately so that misconfiguration
+// (for example an unreadable credentials file) fails at startup rather
+// than on the first gs:// read. Without a gcs section the storage
+// client is constructed lazily on first use (see gcsBlobClient), so
+// providing this module never fails startup for deployments that do
+// not use GCS.
+func newClient(config Config) (BlobStoreClientOut, error) {
+	client := newGcsBlobClient(config)
+	if config.configured {
+		if _, err := client.ensureClient(); err != nil {
+			return BlobStoreClientOut{}, err
+		}
 	}
+	return BlobStoreClientOut{BlobStoreClient: client}, nil
 }

--- a/go/base/blobstore/gcs/module_test.go
+++ b/go/base/blobstore/gcs/module_test.go
@@ -1,0 +1,54 @@
+package gcs
+
+import (
+	"strings"
+	"testing"
+
+	"go.uber.org/config"
+	"go.uber.org/fx"
+
+	"github.com/michelangelo-ai/michelangelo/go/base/blobstore"
+)
+
+// blobStoreClientsIn consumes the blobstore_clients group the same way the
+// worker and controller manager binaries do, forcing fx to run newClient.
+type blobStoreClientsIn struct {
+	fx.In
+	Clients []blobstore.BlobStoreClient `group:"blobstore_clients"`
+}
+
+func newAppFromYAML(t *testing.T, yamlContent string) *fx.App {
+	t.Helper()
+	return fx.New(
+		fx.NopLogger,
+		fx.Provide(func() (config.Provider, error) {
+			return config.NewYAMLProviderFromBytes([]byte(yamlContent))
+		}),
+		Module,
+		fx.Invoke(func(in blobStoreClientsIn) {}),
+	)
+}
+
+func TestModule_StartsWithoutGcsSection(t *testing.T) {
+	app := newAppFromYAML(t, `
+otherKey:
+  value: something
+`)
+	if err := app.Err(); err != nil {
+		t.Fatalf("expected app construction to succeed without a gcs section, got %v", err)
+	}
+}
+
+func TestModule_FailsFastWithBrokenGcsSection(t *testing.T) {
+	app := newAppFromYAML(t, `
+gcs:
+  credentialsFile: /nonexistent/credentials.json
+`)
+	err := app.Err()
+	if err == nil {
+		t.Fatal("expected app construction to fail for a broken gcs section, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to create gcs client") {
+		t.Errorf("expected wrapped gcs construction error, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Follow-up to review feedback on #1837 (https://github.com/michelangelo-ai/michelangelo/pull/1837#discussion_r3834692496): the GCS blob store client is now constructed eagerly at dependency-injection time whenever the application config contains a `gcs` section, so misconfiguration fails at service startup instead of on the first `gs://` read.

- `newConfig` records whether a `gcs` section was present in the config (even an empty one, which still declares intent to use GCS with Application Default Credentials). The flag is an unexported field, so it cannot be set from YAML.
- `newClient` constructs the underlying `storage.Client` immediately when the section is present and returns the construction error, which fails fx application startup. Without a `gcs` section the client stays lazy, exactly as before.
- Added unit tests for both paths plus fx-level module tests proving that a broken `gcs` section fails app construction while an app without the section starts cleanly.

**Why?**

Review feedback on #1837 asked why the client is not created eagerly to catch failures at deployment time. Unconditional eager construction would resolve credentials at startup in every deployment -- including s3- or minio-only installs with no GCP credentials, which would then fail to boot. Constructing eagerly only when the operator has declared a `gcs` config section gives the fail-fast behavior where it is wanted and keeps the zero-cost lazy path everywhere else.

**How did you test it?**

- `go test ./base/blobstore/... -count=1` -- all packages pass, including 6 new tests: presence detection (full, empty, and absent `gcs` sections), eager construction success (anonymous mode), eager construction failure (unreadable credentials file), and fx-level startup tests consuming the `blobstore_clients` group the same way the worker and controller manager binaries do.
- `go test ./base/blobstore/gcs/... -count=1 -race` -- passes.
- `go build ./...`, `go vet ./base/blobstore/gcs/...`, `gofmt -l` -- clean.
- All new tests are hermetic: they use anonymous mode or a deterministically unreadable credentials file, so they do not depend on ADC being present or absent in the environment.

**Potential risks**

A deployment that already declares a `gcs` section pointing at broken configuration (for example an unreadable `credentialsFile`) but never actually reads `gs://` URIs would previously start "successfully" and now fails at startup. That is the intended fail-fast behavior, but it is a startup-behavior change for such deployments; the fix on their side is to correct or remove the stale `gcs` section. Deployments without a `gcs` section are unaffected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

GCS blob store: when a `gcs` config section is present, the client is now constructed at startup so credential or endpoint misconfiguration fails the deployment immediately instead of on the first `gs://` read. Deployments without a `gcs` section keep the lazy construction path and are unaffected.

**Documentation Changes**

None -- behavior is documented in the package godoc comments.
