### PR TITLE
docs(contributing): document the tag-ancestry / merge-back invariant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,6 +303,25 @@ If soak testing finds a problem with an RC:
 
 For a fix to an already-released version, skip the RC flow: cherry-pick the fix to the release branch, update `CHANGELOG.md`, and tag `vX.Y.Z` directly — `release.yaml` publishes the patch the same way it does a final release.
 
+### Tag ancestry and merge-backs
+
+Merge-back PRs (`release/vX.Y` → `main`) are squash-merged, so the tagged
+release commits are **never ancestors of `main`** (`git merge-base
+--is-ancestor v0.8.0 main` returns false — see #1662). This is a known,
+accepted property of the branching model, with one rule attached:
+
+- Any tooling that scopes work between releases must use **explicit
+  tag-to-tag ranges** (`git log vA..vB`), which are well-defined regardless
+  of ancestry. Never resolve versions against `main` via `git describe`,
+  `git merge-base --is-ancestor <tag> main`, or git-cliff's ancestry-based
+  `--latest` — on this repo they will silently misbehave.
+
+`changelog.yml` already follows this rule: it picks the preceding final tag
+by commit timestamp and, when that tag is not a real ancestor, falls back to
+*that tag's own* fork point off `main` (via `git merge-base`) rather than
+hunting for the release branch it came from — a fallback that keeps working
+even after the branch is deleted post-merge (see #2046).
+
 ## Creating a Pull Request
 
 If you want to fix a bug or propose a new feature you’ll do this through creating a Pull Request.


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds a "Tag ancestry and merge-backs" subsection to `CONTRIBUTING.md`'s release-process section, documenting that release tags are never ancestors of `main` (release-branch merge-backs are squash-merged) and the rule that follows from it: tooling that scopes work between releases must use explicit tag-to-tag ranges, never ancestry checks against `main`.

**Why?**

This started as a combined fix (workflow code + docs) that also patched `changelog.yml`'s tag-ancestry fallback -- paulzim reviewed and approved that version. Since then #2064 landed a cleaner fix for the same underlying bug (the release-branch-deletion case that broke v0.10.0-rc.1/v0.10.0), so the workflow-code half here is now fully superseded and conflicts with `main`. Rather than let the whole PR go stale over a diff that's moot, re-scoping to just the docs half: `CONTRIBUTING.md` currently has zero coverage of the tag-ancestry invariant (checked against current `main`), even though it's a real, previously-hit gotcha (#1662) that #2064 shows can bite twice. Worth writing down once so the next person doesn't have to rediscover it via a broken release.

**How did you test it?**

- Re-verified the core claim against current `main`: `git merge-base --is-ancestor v0.8.0 main` still returns false.
- Confirmed `#1662` and `#2046` (both referenced in the new text) are real, closed issues describing the exact bugs mentioned.
- Rewrote the paragraph describing `changelog.yml`'s current fallback mechanism to match what's actually on `main` post-#2064 (tag-based `git merge-base`, not the branch-based fallback the original version of this PR shipped) -- that wording had gone stale by the time I got back to it.
- Confirmed the new subsection sits under the correct parent heading (`## How to Release`, alongside the existing `### Patch releases` / `### Release candidates` subsections) and doesn't need a Table of Contents entry, since sibling `###` subsections aren't listed there either.
- `docs-check.yml` doesn't run against `CONTRIBUTING.md` (its `paths:` filter is `docs/**`, `website/**`, `CHANGELOG.md` only), so there's nothing to validate there beyond reading the rendered markdown by eye.

**Potential risks**

None -- documentation only, no code changed.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Not release-note-worthy (docs only).

**Documentation Changes**

This PR *is* the documentation change -- adds the "Tag ancestry and merge-backs" section to `CONTRIBUTING.md`.
