### PR TITLE
fix(sandbox): record a pod-reachable API endpoint in the compute Cluster CRD

### DIFF
--- a/docs/getting-started/sandbox-setup.md
+++ b/docs/getting-started/sandbox-setup.md
@@ -97,6 +97,8 @@ Docker containers need to communicate with services on your host machine. Verify
    ```
 3. If missing, add it to the end of the file and save.
 
+> **Note:** this only fixes host-side resolution. It does not make `host.docker.internal` (or any other host address) reachable from inside pods — pod-to-host and pod-to-pod traffic requires the sandbox's k3d/docker-network addressing (see `_cluster_endpoint_for_crd` in `sandbox.py`), not `/etc/hosts` edits.
+
 ### Install Python dependencies
 
 From the repository you cloned, install the Michelangelo AI Python packages:

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1937,6 +1937,34 @@ def _ensure_namespace_exists(namespace: str):
         print(f"Created namespace '{namespace}' in the sandbox cluster.")
 
 
+def _cluster_endpoint_for_crd(cluster_name: str, server_url: str) -> tuple[str, str]:
+    """Pick an API endpoint for the Cluster CRD that is reachable from inside pods.
+
+    `k3d kubeconfig get` returns the host-side endpoint (for example
+    `https://0.0.0.0:59896`), which the controllermgr cannot reach from inside
+    the cluster. Returns a `(host, port)` pair that pods can actually dial.
+    """
+    if cluster_name == _michelangelo_sandbox_kube_cluster_name:
+        # The sandbox cluster itself: use the in-cluster service endpoint.
+        return "https://kubernetes.default.svc", "443"
+
+    import re
+
+    match = re.search(r"(https://[^:]+):(\d+)", server_url)
+    if not match:
+        raise ValueError(
+            f"Could not extract cluster host and port from server URL: {server_url}"
+        )
+    host, port = match.groups()
+
+    unroutable = {"0.0.0.0", "127.0.0.1", "localhost", "host.docker.internal"}
+    if host.removeprefix("https://") in unroutable:
+        # Another k3d cluster on the shared docker network: its server
+        # container name resolves from pods and its port is stable.
+        return f"https://k3d-{cluster_name}-server-0", "6443"
+    return host, port
+
+
 # Given a cluster name, create a Cluster CRD in the sandbox cluster
 def _create_compute_cluster_crd(cluster_name: str):
     """Create a Cluster CRD for the Ray jobs cluster in the sandbox cluster."""
@@ -1954,16 +1982,7 @@ def _create_compute_cluster_crd(cluster_name: str):
     # Extract server URL from clusters[0].cluster.server
     server_url = kubeconfig_data["clusters"][0]["cluster"]["server"]
 
-    # Extract host and port from server URL
-    # Example: "https://host.docker.internal:52910"
-    import re
-
-    match = re.search(r"(https://[^:]+):(\d+)", server_url)
-    if not match:
-        raise ValueError(
-            f"Could not extract cluster host and port from server URL: {server_url}"
-        )
-    host, port = match.groups()
+    host, port = _cluster_endpoint_for_crd(cluster_name, server_url)
 
     # Create Cluster CRD manifest
     cluster_crd = {

--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -30,6 +30,17 @@ _michelangelo_sandbox_kube_cluster_name = "michelangelo-sandbox"
 _cadence_domain = "default"
 _default_compute_kube_cluster_name = "michelangelo-compute-0"
 
+# Hosts that `k3d kubeconfig get` may return but that are not reachable from
+# inside pods (host-side loopback/docker-gateway addresses).
+_unroutable_cluster_hosts = {
+    "0.0.0.0",
+    "127.0.0.1",
+    "localhost",
+    "host.docker.internal",
+}
+# Port the k3d server container listens on within the shared docker network.
+_k3d_server_port = "6443"
+
 # Path to the Michelangelo Helm chart (relative to this file)
 _chart_dir = Path(__file__).parent.parent.parent.parent.parent / "helm" / "michelangelo"
 
@@ -1957,11 +1968,10 @@ def _cluster_endpoint_for_crd(cluster_name: str, server_url: str) -> tuple[str, 
         )
     host, port = match.groups()
 
-    unroutable = {"0.0.0.0", "127.0.0.1", "localhost", "host.docker.internal"}
-    if host.removeprefix("https://") in unroutable:
+    if host.removeprefix("https://") in _unroutable_cluster_hosts:
         # Another k3d cluster on the shared docker network: its server
         # container name resolves from pods and its port is stable.
-        return f"https://k3d-{cluster_name}-server-0", "6443"
+        return f"https://k3d-{cluster_name}-server-0", _k3d_server_port
     return host, port
 
 

--- a/python/michelangelo/cli/sandbox/sandbox_test.py
+++ b/python/michelangelo/cli/sandbox/sandbox_test.py
@@ -193,3 +193,41 @@ class SnapshotRestoreTest(TestCase):
         ):
             sandbox._snapshot_restore(argparse.Namespace(timestamp="does-not-exist"))
         mock_err.assert_called_once()
+
+
+class ClusterEndpointForCrdTest(TestCase):
+    """Test cases for `_cluster_endpoint_for_crd`."""
+
+    def test_sandbox_cluster_uses_in_cluster_endpoint(self):
+        """The sandbox's own cluster always maps to kubernetes.default.svc."""
+        host, port = sandbox._cluster_endpoint_for_crd(
+            sandbox._michelangelo_sandbox_kube_cluster_name,
+            "https://0.0.0.0:59896",
+        )
+        self.assertEqual(host, "https://kubernetes.default.svc")
+        self.assertEqual(port, "443")
+
+    def test_unroutable_host_maps_to_k3d_server_container(self):
+        """0.0.0.0 and friends map to the k3d server container endpoint."""
+        for server_url in (
+            "https://0.0.0.0:59896",
+            "https://127.0.0.1:52910",
+            "https://localhost:52910",
+            "https://host.docker.internal:52910",
+        ):
+            host, port = sandbox._cluster_endpoint_for_crd("ray-jobs", server_url)
+            self.assertEqual(host, "https://k3d-ray-jobs-server-0")
+            self.assertEqual(port, "6443")
+
+    def test_routable_host_passes_through_unchanged(self):
+        """A genuinely reachable address is kept verbatim."""
+        host, port = sandbox._cluster_endpoint_for_crd(
+            "remote-cluster", "https://api.remote.example.com:6443"
+        )
+        self.assertEqual(host, "https://api.remote.example.com")
+        self.assertEqual(port, "6443")
+
+    def test_malformed_server_url_raises(self):
+        """A server URL without host:port raises ValueError."""
+        with self.assertRaises(ValueError):
+            sandbox._cluster_endpoint_for_crd("ray-jobs", "not-a-url")


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Fixes #1901: `_create_compute_cluster_crd` copied the API server address straight out of `k3d kubeconfig get` into the `Cluster` CRD. That is the host-side endpoint (for example `https://0.0.0.0:59896`), which the controllermgr cannot reach from inside the cluster, so every KubeRay `RayCluster` creation failed with `connection refused` and no `rayclusters.ray.io` object was ever created.

The endpoint now goes through a small helper, `_cluster_endpoint_for_crd`:

- The sandbox cluster itself maps to the in-cluster service endpoint, `https://kubernetes.default.svc:443` -- the fix the issue reporter verified live.
- For any other k3d compute cluster, a known-unroutable host (`0.0.0.0`, `127.0.0.1`, `localhost`, `host.docker.internal`) maps to the cluster's server container on the shared docker network, `https://k3d-<name>-server-0:6443`, which pods can resolve (per the issue's reachability table) and whose port is stable across cluster recreations, unlike the host-mapped port that re-randomises on every `k3d cluster create`.
- A genuinely routable address passes through unchanged.

**Why?**

The controllermgr runs inside the cluster; `0.0.0.0` is a bind address there, not a destination, and the `host.docker.internal` name the old code comment expected does not resolve from pods either. Writing either into the CRD breaks every Ray-backed pipeline task on a fresh sandbox.

**How did you test it?**

- 4 new unit tests on the helper: sandbox cluster maps to `kubernetes.default.svc:443`; each unroutable host maps to the k3d server container endpoint; a routable address passes through verbatim; a malformed server URL raises. Full sandbox CLI suite passes (10 tests).
- `ruff check` and `ruff format --check` clean on both touched files.
- The in-cluster endpoint itself is the fix the issue reporter verified by patching a live sandbox (their "Verified fix" section), and the `k3d-<name>-server-0:6443` reachability is from the same report's table.

**Potential risks**

- A deployment whose kubeconfig legitimately reports a loopback address that is somehow reachable from pods (for example a host-network setup outside k3d) would now be rewritten to the k3d container name. The sandbox CLI only creates k3d clusters, so this combination does not arise from `ma sandbox` itself.
- The multi-cluster (non-sandbox) mapping is grounded on the issue's reachability table rather than an end-to-end run here; the sandbox-itself path is the reporter-verified one.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Sandbox: the compute `Cluster` CRD now records an API endpoint reachable from inside the cluster (in-cluster service endpoint for the sandbox itself, the k3d server container address for other local clusters), so KubeRay `RayCluster` objects are actually created and Ray-backed pipeline tasks run.

**Documentation Changes**

None -- no user-facing parameter changes; the sandbox just works as documented.