### PR TITLE
fix(sandbox): back the mysql Pod with a data volume so restarts keep the databases

### DIFF
--- a/python/michelangelo/cli/sandbox/resources/mysql.yaml
+++ b/python/michelangelo/cli/sandbox/resources/mysql.yaml
@@ -19,6 +19,9 @@ spec:
           value: temporal
       # Note: Cadence auto-setup will create cadence/cadence_visibility databases
       # Ingester will create michelangelo database via mysql-ingester.yaml Job
+      volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: mysql-data
       readinessProbe:
         exec:
           command:
@@ -49,6 +52,11 @@ spec:
         timeoutSeconds: 5
         successThreshold: 1
         failureThreshold: 3
+  volumes:
+    - name: mysql-data
+      hostPath:
+        path: /shared/mysql-data
+        type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Fixes #1908: the sandbox mysql Pod (`python/michelangelo/cli/sandbox/resources/mysql.yaml`) declared no volumes at all, so all data lived in the container's writable layer and any restart -- VM restart, `k3d cluster stop && start`, pod recreation -- destroyed the `cadence`, `cadence_visibility`, and `michelangelo` databases. The Cadence tier then wedged indefinitely on `wait-for-schema`, because the schema Job is already `Complete` and never re-runs.

This mounts `/var/lib/mysql` from a `hostPath` volume (`/shared/mysql-data`, `DirectoryOrCreate`) -- exactly the pattern the sandbox's minio Pod already uses for `/data` (`/shared/minio-data`), which the issue notes survived every restart in the reporter's testing.

**Why?**

`ma sandbox stop` / `ma sandbox start` are documented lifecycle commands; they should return a working environment, not one whose entire database tier is gone. This is the issue's suggested fix, kept deliberately minimal: it does not convert the bare Pod to a Deployment/StatefulSet, both to stay one-concern and because the in-flight #1958 adds sync-time self-healing that operates on the Pod by name -- the two changes compose (self-heal revives the Pod, this volume makes the revival lossless).

**How did you test it?**

- YAML parses (`yaml.safe_load_all`) and the Pod spec's `volumeMounts`/`volumes` structure verified programmatically to match the minio precedent.
- The mysql:8.0 image's entrypoint skips database initialization when the data directory is non-empty, so a restarted Pod picks up the existing databases -- standard image behavior, the same contract minio relies on.
- Not exercised end-to-end here (no local k3d): the restart scenario is the issue's own reproduction; with the volume, step 4's `Unknown database 'cadence'` cannot occur since the datadir persists.

**Potential risks**

- Stale data now persists across `ma sandbox delete`/`create` cycles on the same host if the k3d volume mount recurs, where before every mysql Pod started fresh. `_refresh_mysql_schema` already drops and recreates the `michelangelo` database on every sync, which covers the platform schema; Cadence keeps its history, which is the point of the fix.
- Disk usage on the host node grows with retained history (same profile as the existing minio hostPath).

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Sandbox: the mysql Pod now stores its data on a hostPath volume, so the Cadence and platform databases survive VM restarts, `k3d cluster stop/start`, and Pod recreation.

**Documentation Changes**

None -- documented lifecycle commands (`ma sandbox stop`/`start`) now behave as documented.