### PR TITLE
feat(helm): expose secrets provider selection in the chart

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -136,6 +136,22 @@ jobs:
             --set controllermgr.enabled=false \
             2>/dev/null
 
+      - name: Template — ESO secrets provider enabled
+        run: |
+          helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set secretsProvider.type=eso \
+            --set secretsProvider.esoNamespace=ma-secrets \
+            --debug \
+            > /dev/null
+
+      - name: Validate fail-fast guard (unknown secretsProvider.type must fail)
+        run: |
+          ! helm template michelangelo helm/michelangelo \
+            -f helm/michelangelo/values-k3d.yaml \
+            --set secretsProvider.type=vault \
+            2>/dev/null
+
       - name: Template — Ingress enabled (UI + Envoy, hosts[] syntax)
         run: |
           helm template michelangelo helm/michelangelo \

--- a/docs/operator-guides/helm-chart.md
+++ b/docs/operator-guides/helm-chart.md
@@ -138,6 +138,26 @@ monitoring:
 
 Every resource is CRD-gated — anything whose operator CRDs are absent is skipped, so the toggle is safe on any cluster. See [Monitoring & Observability](operations/monitoring.md) for the sub-toggles and the metrics behind each artifact.
 
+### Source remote-cluster credentials from an external secret store
+
+Remote-cluster credentials (the CA bundle and token Secrets referenced by
+cluster specs) default to the sample provider, which reads Secrets from the
+control-plane cluster and is intended for sandbox and testing. For
+production, install the [External Secrets Operator](https://external-secrets.io)
+and switch the provider:
+
+```yaml
+secretsProvider:
+  type: eso
+  esoNamespace: ma-secrets   # where your ExternalSecret resources sync Secrets to
+```
+
+You manage the `ExternalSecret` resources yourself (one per credential
+Secret, named to match the cluster spec's `caDataTag` / `tokenTag`), pointed
+at whatever store your operator is configured for -- Vault, AWS Secrets
+Manager, GCP Secret Manager, and so on. The services fail with a clear error
+if the operator's CRDs are absent or a referenced Secret has not synced.
+
 ### Expose the UI and API
 
 The chart includes per-service Ingress templates (`apiserver.ingress`, `envoy.ingress`, `ui.ingress`). Enable and configure them to expose the UI and API outside the cluster:

--- a/go/cmd/controllermgr/config/base.yaml
+++ b/go/cmd/controllermgr/config/base.yaml
@@ -81,3 +81,10 @@ inferenceServer:
     serviceName: ma-gateway-istio
     serviceNamespace: default
     portName: http
+# Secret provider selection for cluster credentials (jobs engine and
+# inference-server client factory). Defaults to the sample provider, which
+# reads Secrets from the control-plane cluster.
+# secrets:
+#   provider: eso  # "sample" (default) or "eso" (External Secrets Operator)
+#   eso:
+#     namespace: ""  # Optional: where operator-synced Secrets live (default "default")

--- a/go/components/inferenceserver/clientfactory/BUILD.bazel
+++ b/go/components/inferenceserver/clientfactory/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/michelangelo-ai/michelangelo/go/components/inferenceserver/clientfactory",
     visibility = ["//visibility:public"],
     deps = [
+        "//go/base/config:go_default_library",
         "//go/components/inferenceserver/clientfactory/secrets:go_default_library",
         "//proto/api/v2:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
@@ -20,6 +21,19 @@ go_library(
         "@io_k8s_client_go//util/flowcontrol:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@org_uber_go_fx//:go_default_library",
+        "@org_uber_go_zap//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["module_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//go/components/inferenceserver/clientfactory/secrets:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/go/components/inferenceserver/clientfactory/module.go
+++ b/go/components/inferenceserver/clientfactory/module.go
@@ -1,22 +1,46 @@
 package clientfactory
 
 import (
+	"fmt"
+
 	"go.uber.org/fx"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	baseconfig "github.com/michelangelo-ai/michelangelo/go/base/config"
 	"github.com/michelangelo-ai/michelangelo/go/components/inferenceserver/clientfactory/secrets"
 )
 
 // Module wires the ClientFactory into the fx graph.
 var Module = fx.Options(
+	fx.Provide(baseconfig.ProvideConfig[secrets.Config](secrets.ConfigKey)),
 	fx.Provide(newClientFactory),
 )
 
-func newClientFactory(kubeClient client.Client, logger *zap.Logger) ClientFactory {
+func newClientFactory(kubeClient client.Client, cfg secrets.Config, logger *zap.Logger) (ClientFactory, error) {
+	provider, err := newSecretProvider(kubeClient, cfg)
+	if err != nil {
+		return nil, err
+	}
 	return NewRemoteClientFactory(
-		secrets.NewProvider(kubeClient),
+		provider,
 		kubeClient.Scheme(),
 		logger,
-	)
+	), nil
+}
+
+// newSecretProvider returns the SecretProvider selected by
+// `secrets.provider`: the sample control-plane provider by default, or the
+// External Secrets Operator backed provider when configured as "eso".
+func newSecretProvider(kubeClient client.Client, cfg secrets.Config) (secrets.SecretProvider, error) {
+	switch cfg.Provider {
+	case "", secrets.ProviderSample:
+		return secrets.NewProvider(kubeClient), nil
+	case secrets.ProviderESO:
+		return secrets.NewESOProvider(kubeClient, cfg.ESO), nil
+	default:
+		return nil, fmt.Errorf(
+			"unknown secrets.provider %q: must be %q or %q",
+			cfg.Provider, secrets.ProviderSample, secrets.ProviderESO)
+	}
 }

--- a/go/components/inferenceserver/clientfactory/module_test.go
+++ b/go/components/inferenceserver/clientfactory/module_test.go
@@ -1,0 +1,55 @@
+package clientfactory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/michelangelo-ai/michelangelo/go/components/inferenceserver/clientfactory/secrets"
+)
+
+func TestNewSecretProviderSelection(t *testing.T) {
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+	tests := []struct {
+		name      string
+		cfg       secrets.Config
+		expectESO bool
+		expectErr string
+	}{
+		{name: "default is sample", cfg: secrets.Config{}},
+		{name: "explicit sample", cfg: secrets.Config{Provider: secrets.ProviderSample}},
+		{name: "eso", cfg: secrets.Config{Provider: secrets.ProviderESO}, expectESO: true},
+		{name: "unknown provider", cfg: secrets.Config{Provider: "vault"}, expectErr: "unknown secrets.provider"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := newSecretProvider(kubeClient, tt.cfg)
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.expectESO {
+				require.IsType(t, &secrets.ESOProvider{}, provider)
+			} else {
+				require.IsType(t, &secrets.Provider{}, provider)
+			}
+		})
+	}
+}
+
+func TestNewClientFactory(t *testing.T) {
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+
+	factory, err := newClientFactory(kubeClient, secrets.Config{}, zap.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+
+	_, err = newClientFactory(kubeClient, secrets.Config{Provider: "vault"}, zap.NewNop())
+	require.Error(t, err)
+}

--- a/go/components/inferenceserver/clientfactory/secrets/BUILD.bazel
+++ b/go/components/inferenceserver/clientfactory/secrets/BUILD.bazel
@@ -1,14 +1,37 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["provider.go"],
+    srcs = [
+        "eso.go",
+        "provider.go",
+    ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/components/inferenceserver/clientfactory/secrets",
     visibility = ["//visibility:public"],
     deps = [
         "//proto/api/v2:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/meta:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["eso_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/api/v2:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/meta:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/go/components/inferenceserver/clientfactory/secrets/eso.go
+++ b/go/components/inferenceserver/clientfactory/secrets/eso.go
@@ -1,0 +1,141 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// Provider selection values for Config.Provider.
+const (
+	// ProviderSample selects the sample implementation that reads secrets
+	// from the control-plane cluster. This is the default.
+	ProviderSample = "sample"
+	// ProviderESO selects the External Secrets Operator backed
+	// implementation.
+	ProviderESO = "eso"
+)
+
+// ConfigKey is the YAML key the secrets configuration is read from. The jobs
+// engine reads the same key, so one config block selects the secret provider
+// for both consumers.
+const ConfigKey = "secrets"
+
+// esoAPIGroup is the API group registered by the External Secrets Operator's
+// CRDs. Its presence is how the provider verifies the operator is installed.
+const esoAPIGroup = "external-secrets.io"
+
+// Config selects and configures the SecretProvider implementation.
+type Config struct {
+	// Provider is "sample" (default) or "eso".
+	Provider string `yaml:"provider"`
+	// ESO configures the External Secrets Operator backed provider.
+	ESO ESOConfig `yaml:"eso"`
+}
+
+// ESOConfig configures the External Secrets Operator backed provider.
+type ESOConfig struct {
+	// Namespace is where the operator-synced credential Secrets live.
+	// Defaults to "default", matching the sample provider.
+	Namespace string `yaml:"namespace"`
+}
+
+var _ SecretProvider = (*ESOProvider)(nil)
+
+// ESOProvider implements SecretProvider on top of the External Secrets
+// Operator: credential Secrets are expected to be materialized in-cluster by
+// ExternalSecret resources synced from an external store (Vault, AWS Secrets
+// Manager, GCP Secret Manager, ...). The provider reads those synced Secrets
+// and fails with a clear error when the operator's CRDs are absent, so a
+// misconfigured deployment degrades loudly rather than mysteriously.
+type ESOProvider struct {
+	kubeClient client.Client
+	namespace  string
+
+	// operatorVerified caches a successful CRD-presence check. Failed checks
+	// are not cached, so a transient discovery error does not wedge the
+	// provider.
+	operatorVerified atomic.Bool
+}
+
+// NewESOProvider returns a SecretProvider backed by External Secrets
+// Operator managed Secrets.
+func NewESOProvider(kubeClient client.Client, cfg ESOConfig) *ESOProvider {
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = secretsNamespace
+	}
+	return &ESOProvider{kubeClient: kubeClient, namespace: namespace}
+}
+
+// ensureOperator verifies the External Secrets Operator CRDs are installed,
+// caching a successful check for the lifetime of the provider.
+func (p *ESOProvider) ensureOperator() error {
+	if p.operatorVerified.Load() {
+		return nil
+	}
+	_, err := p.kubeClient.RESTMapper().RESTMapping(schema.GroupKind{Group: esoAPIGroup, Kind: "ExternalSecret"})
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return fmt.Errorf(
+				"secrets provider is configured as %q but the ExternalSecret kind (%s) is not registered: "+
+					"the external secrets operator does not appear to be installed in this cluster; "+
+					"install it or set secrets.provider to %q", ProviderESO, esoAPIGroup, ProviderSample)
+		}
+		return fmt.Errorf("failed to check for the external secrets operator: %w", err)
+	}
+	p.operatorVerified.Store(true)
+	return nil
+}
+
+// GetClientAuth fetches the CA certificate and bearer token from
+// operator-synced Secrets for the given ClusterTarget.
+func (p *ESOProvider) GetClientAuth(ctx context.Context, cluster *v2pb.ClusterTarget) (ClientAuth, error) {
+	if err := p.ensureOperator(); err != nil {
+		return ClientAuth{}, err
+	}
+	if cluster.GetKubernetes() == nil {
+		return ClientAuth{}, fmt.Errorf("cluster %q has no kubernetes connection spec", cluster.GetClusterId())
+	}
+
+	caSecret, err := p.fetchSecret(ctx, cluster.GetKubernetes().GetCaDataTag())
+	if err != nil {
+		return ClientAuth{}, fmt.Errorf("CA secret for cluster %q: %w", cluster.GetClusterId(), err)
+	}
+	tokenSecret, err := p.fetchSecret(ctx, cluster.GetKubernetes().GetTokenTag())
+	if err != nil {
+		return ClientAuth{}, fmt.Errorf("token secret for cluster %q: %w", cluster.GetClusterId(), err)
+	}
+
+	return ClientAuth{
+		CertificateAuthorityData: string(caSecret.Data[caDataKey]),
+		ClientTokenData:          string(tokenSecret.Data[tokenKey]),
+	}, nil
+}
+
+func (p *ESOProvider) fetchSecret(ctx context.Context, name string) (*corev1.Secret, error) {
+	if name == "" {
+		return nil, fmt.Errorf("empty secret name")
+	}
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: name, Namespace: p.namespace}
+	if err := p.kubeClient.Get(ctx, key, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf(
+				"get secret %s/%s: not found; if it is managed by an ExternalSecret, check that the "+
+					"ExternalSecret exists and has synced (kubectl get externalsecret -n %s): %w",
+				p.namespace, name, p.namespace, err)
+		}
+		return nil, fmt.Errorf("get secret %s/%s: %w", p.namespace, name, err)
+	}
+	return secret, nil
+}

--- a/go/components/inferenceserver/clientfactory/secrets/eso_test.go
+++ b/go/components/inferenceserver/clientfactory/secrets/eso_test.go
@@ -1,0 +1,134 @@
+package secrets
+
+import (
+	"context"
+	"testing"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// newRESTMapper returns a RESTMapper that optionally knows about the
+// ExternalSecret kind, simulating the operator's CRDs being installed.
+func newRESTMapper(withESO bool) meta.RESTMapper {
+	corev1GV := schema.GroupVersion{Version: "v1"}
+	esoGV := schema.GroupVersion{Group: esoAPIGroup, Version: "v1beta1"}
+	groupVersions := []schema.GroupVersion{corev1GV}
+	if withESO {
+		groupVersions = append(groupVersions, esoGV)
+	}
+	mapper := meta.NewDefaultRESTMapper(groupVersions)
+	mapper.Add(corev1GV.WithKind("Secret"), meta.RESTScopeNamespace)
+	if withESO {
+		mapper.Add(esoGV.WithKind("ExternalSecret"), meta.RESTScopeNamespace)
+	}
+	return mapper
+}
+
+func newFakeClient(withESO bool, objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRESTMapper(newRESTMapper(withESO)).
+		WithObjects(objects...).
+		Build()
+}
+
+func clusterTarget(caTag, tokenTag string) *v2pb.ClusterTarget {
+	return &v2pb.ClusterTarget{
+		ClusterId: "test-cluster",
+		Connection: &v2pb.ClusterTarget_Kubernetes{
+			Kubernetes: &v2pb.ConnectionSpec{
+				CaDataTag: caTag,
+				TokenTag:  tokenTag,
+			},
+		},
+	}
+}
+
+func credentialSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       data,
+	}
+}
+
+func TestESOProviderGetClientAuth(t *testing.T) {
+	kubeClient := newFakeClient(true,
+		credentialSecret("ca-secret", "ma-secrets", map[string][]byte{caDataKey: []byte("fake-ca")}),
+		credentialSecret("token-secret", "ma-secrets", map[string][]byte{tokenKey: []byte("fake-token")}),
+	)
+	provider := NewESOProvider(kubeClient, ESOConfig{Namespace: "ma-secrets"})
+
+	auth, err := provider.GetClientAuth(context.Background(), clusterTarget("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	require.Equal(t, ClientAuth{
+		CertificateAuthorityData: "fake-ca",
+		ClientTokenData:          "fake-token",
+	}, auth)
+}
+
+func TestESOProviderDefaultNamespace(t *testing.T) {
+	kubeClient := newFakeClient(true,
+		credentialSecret("ca-secret", secretsNamespace, map[string][]byte{caDataKey: []byte("fake-ca")}),
+		credentialSecret("token-secret", secretsNamespace, map[string][]byte{tokenKey: []byte("fake-token")}),
+	)
+	provider := NewESOProvider(kubeClient, ESOConfig{})
+
+	auth, err := provider.GetClientAuth(context.Background(), clusterTarget("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	require.Equal(t, "fake-ca", auth.CertificateAuthorityData)
+}
+
+func TestESOProviderOperatorAbsent(t *testing.T) {
+	provider := NewESOProvider(newFakeClient(false), ESOConfig{})
+
+	_, err := provider.GetClientAuth(context.Background(), clusterTarget("ca-secret", "token-secret"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "external secrets operator does not appear to be installed")
+}
+
+func TestESOProviderMissingSecretGuidance(t *testing.T) {
+	provider := NewESOProvider(newFakeClient(true), ESOConfig{Namespace: "ma-secrets"})
+
+	_, err := provider.GetClientAuth(context.Background(), clusterTarget("missing-ca", "missing-token"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "check that the ExternalSecret exists and has synced")
+	require.Contains(t, err.Error(), "ma-secrets/missing-ca")
+}
+
+func TestESOProviderNoKubernetesSpec(t *testing.T) {
+	provider := NewESOProvider(newFakeClient(true), ESOConfig{})
+
+	_, err := provider.GetClientAuth(context.Background(), &v2pb.ClusterTarget{ClusterId: "test-cluster"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no kubernetes connection spec")
+}
+
+func TestESOProviderEmptySecretName(t *testing.T) {
+	provider := NewESOProvider(newFakeClient(true), ESOConfig{})
+
+	_, err := provider.GetClientAuth(context.Background(), clusterTarget("", ""))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty secret name")
+}
+
+func TestESOProviderCachesOperatorCheck(t *testing.T) {
+	kubeClient := newFakeClient(true,
+		credentialSecret("ca-secret", secretsNamespace, map[string][]byte{caDataKey: []byte("fake-ca")}),
+		credentialSecret("token-secret", secretsNamespace, map[string][]byte{tokenKey: []byte("fake-token")}),
+	)
+	provider := NewESOProvider(kubeClient, ESOConfig{})
+
+	_, err := provider.GetClientAuth(context.Background(), clusterTarget("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	// Second call takes the cached-verification path.
+	_, err = provider.GetClientAuth(context.Background(), clusterTarget("ca-secret", "token-secret"))
+	require.NoError(t, err)
+}

--- a/go/components/inferenceserver/clientfactory/secrets/provider.go
+++ b/go/components/inferenceserver/clientfactory/secrets/provider.go
@@ -46,8 +46,9 @@ type SecretProvider interface {
 // The secret names are pulled from the ClusterTarget's `CaDataTag` and `TokenTag` fields.
 //
 // NOTE: This implementation is intended for sandbox and testing use. Production deployments
-// should use an external secret manager (e.g. HashiCorp Vault, AWS Secrets Manager, GCP
-// Secret Manager) and provide their own SecretProvider implementation.
+// should set `secrets.provider: eso` to use the External Secrets Operator backed
+// ESOProvider, which sources credentials from an external secret manager (e.g. HashiCorp
+// Vault, AWS Secrets Manager, GCP Secret Manager).
 type Provider struct {
 	kubeClient client.Client
 }

--- a/go/components/jobs/client/client_test.go
+++ b/go/components/jobs/client/client_test.go
@@ -590,7 +590,9 @@ func TestCreateSecret(t *testing.T) {
 				CoreV1: c.RESTClient(),
 			}, test.getClientSetError)
 
-			provider := secrets.New(secrets.Params{}).SecretProvider
+			secretsResult, err := secrets.New(secrets.Params{})
+			require.NoError(t, err)
+			provider := secretsResult.SecretProvider
 
 			k8sc := Client{
 				factory:         f,
@@ -600,7 +602,7 @@ func TestCreateSecret(t *testing.T) {
 			}
 
 			// test
-			err := k8sc.CreateSecret(context.Background(), test.jobInput, &testCluster)
+			err = k8sc.CreateSecret(context.Background(), test.jobInput, &testCluster)
 			if test.wantError != "" {
 				require.NotNil(t, err)
 				require.Error(t, err)

--- a/go/components/jobs/common/secrets/BUILD.bazel
+++ b/go/components/jobs/common/secrets/BUILD.bazel
@@ -3,14 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "config.go",
+        "eso.go",
         "module.go",
         "secrets.go",
     ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/secrets",
     visibility = ["//visibility:public"],
     deps = [
+        "//go/base/config:go_default_library",
         "//go/components/jobs/common/constants:go_default_library",
         "//proto/api/v2:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
@@ -23,7 +27,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["secrets_test.go"],
+    srcs = [
+        "eso_test.go",
+        "secrets_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//proto/api/v2:go_default_library",
@@ -31,6 +38,9 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//discovery/fake:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
+        "@io_k8s_client_go//testing:go_default_library",
     ],
 )

--- a/go/components/jobs/common/secrets/config.go
+++ b/go/components/jobs/common/secrets/config.go
@@ -1,0 +1,31 @@
+package secrets
+
+// Provider selection values for Config.Provider.
+const (
+	// ProviderSample selects the sample implementation that reads secrets
+	// from the control-plane cluster. This is the default.
+	ProviderSample = "sample"
+	// ProviderESO selects the External Secrets Operator backed
+	// implementation.
+	ProviderESO = "eso"
+)
+
+// configKey is the YAML key the secrets configuration is read from. The
+// inference-server client factory reads the same key, so one config block
+// selects the secret provider for both consumers.
+const configKey = "secrets"
+
+// Config selects and configures the SecretProvider implementation.
+type Config struct {
+	// Provider is "sample" (default) or "eso".
+	Provider string `yaml:"provider"`
+	// ESO configures the External Secrets Operator backed provider.
+	ESO ESOConfig `yaml:"eso"`
+}
+
+// ESOConfig configures the External Secrets Operator backed provider.
+type ESOConfig struct {
+	// Namespace is where the operator-synced credential Secrets live.
+	// Defaults to "default", matching the sample provider.
+	Namespace string `yaml:"namespace"`
+}

--- a/go/components/jobs/common/secrets/eso.go
+++ b/go/components/jobs/common/secrets/eso.go
@@ -1,0 +1,127 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"go.uber.org/zap"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// esoAPIGroup is the API group registered by the External Secrets Operator's
+// CRDs. Its presence is how the provider verifies the operator is installed.
+const esoAPIGroup = "external-secrets.io"
+
+var _ SecretProvider = (*ESOProvider)(nil)
+
+// ESOProvider implements SecretProvider on top of the External Secrets
+// Operator: credential Secrets are expected to be materialized in-cluster by
+// ExternalSecret resources synced from an external store (Vault, AWS Secrets
+// Manager, GCP Secret Manager, ...). The provider reads those synced Secrets
+// and fails with a clear error when the operator's CRDs are absent, so a
+// misconfigured deployment degrades loudly rather than mysteriously.
+type ESOProvider struct {
+	k8sClusterClient kubernetes.Interface
+	namespace        string
+	logger           *zap.Logger
+
+	// operatorVerified caches a successful CRD-presence check. Failed checks
+	// are not cached, so a transient discovery error does not wedge the
+	// provider.
+	operatorVerified atomic.Bool
+}
+
+// NewESOProvider returns a SecretProvider backed by External Secrets
+// Operator managed Secrets.
+func NewESOProvider(clientSet kubernetes.Interface, cfg ESOConfig, logger *zap.Logger) *ESOProvider {
+	namespace := cfg.Namespace
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &ESOProvider{
+		k8sClusterClient: clientSet,
+		namespace:        namespace,
+		logger:           logger,
+	}
+}
+
+// ensureOperator verifies the External Secrets Operator CRDs are installed,
+// caching a successful check for the lifetime of the provider.
+func (p *ESOProvider) ensureOperator() error {
+	if p.operatorVerified.Load() {
+		return nil
+	}
+	groups, err := p.k8sClusterClient.Discovery().ServerGroups()
+	if err != nil {
+		return fmt.Errorf("failed to discover API groups while checking for the external secrets operator: %w", err)
+	}
+	for _, group := range groups.Groups {
+		if group.Name == esoAPIGroup {
+			p.operatorVerified.Store(true)
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"secrets provider is configured as %q but the %s API group is not registered: "+
+			"the external secrets operator does not appear to be installed in this cluster; "+
+			"install it or set secrets.provider to %q", ProviderESO, esoAPIGroup, ProviderSample)
+}
+
+// retrieveSecretData reads one key from an operator-synced Secret.
+func (p *ESOProvider) retrieveSecretData(ctx context.Context, secretName, dataKey string) (string, error) {
+	secret, err := p.k8sClusterClient.CoreV1().Secrets(p.namespace).Get(ctx, secretName, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", fmt.Errorf(
+				"failed to get %s: secret %s/%s not found; if it is managed by an ExternalSecret, "+
+					"check that the ExternalSecret exists and has synced "+
+					"(kubectl get externalsecret -n %s): %w",
+				dataKey, p.namespace, secretName, p.namespace, err)
+		}
+		return "", fmt.Errorf("failed to get %s: %w", dataKey, err)
+	}
+	return string(secret.Data[dataKey]), nil
+}
+
+// GetClusterClientAuth retrieves the client authentication data for a given
+// cluster from operator-synced Secrets.
+func (p *ESOProvider) GetClusterClientAuth(ctx context.Context, cluster *v2pb.Cluster) (ClientAuth, error) {
+	if err := p.ensureOperator(); err != nil {
+		return ClientAuth{}, err
+	}
+
+	var kubeClusterSpec *v2pb.KubernetesSpec
+	switch cluster.Spec.GetCluster().(type) {
+	case *v2pb.ClusterSpec_Kubernetes:
+		kubeClusterSpec = cluster.Spec.GetKubernetes()
+	default:
+		return ClientAuth{}, fmt.Errorf("cluster type %s not supported", cluster.Spec.GetCluster())
+	}
+
+	caDataDecoded, err := p.retrieveSecretData(ctx, kubeClusterSpec.Rest.CaDataTag, "cadata")
+	if err != nil {
+		return ClientAuth{}, err
+	}
+	clientTokenDecoded, err := p.retrieveSecretData(ctx, kubeClusterSpec.Rest.TokenTag, "token")
+	if err != nil {
+		return ClientAuth{}, err
+	}
+
+	return ClientAuth{
+		CertificateAuthorityData: caDataDecoded,
+		ClientTokenData:          clientTokenDecoded,
+	}, nil
+}
+
+// GetSecretsForDataStore mirrors the sample provider's current contract: no
+// data-store secrets are injected today by any provider, so this returns
+// nil until the consumer defines what data-store secrets look like.
+func (p *ESOProvider) GetSecretsForDataStore(ctx context.Context, jobObject runtime.Object, cluster *v2pb.Cluster) (map[string][]byte, error) {
+	return nil, nil
+}

--- a/go/components/jobs/common/secrets/eso_test.go
+++ b/go/components/jobs/common/secrets/eso_test.go
@@ -1,0 +1,184 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// newFakeClientSetWithESO returns a fake clientset whose discovery reports
+// the external-secrets.io API group as present (operator installed).
+func newFakeClientSetWithESO(t *testing.T, objects ...runtime.Object) kubernetes.Interface {
+	t.Helper()
+	fakeClientSet := fakek8sclient.NewSimpleClientset(objects...)
+	discovery, ok := fakeClientSet.Discovery().(*fakediscovery.FakeDiscovery)
+	require.True(t, ok)
+	discovery.Resources = []*v1.APIResourceList{
+		{GroupVersion: esoAPIGroup + "/v1beta1"},
+	}
+	return fakeClientSet
+}
+
+func kubeCluster(caTag, tokenTag string) *v2pb.Cluster {
+	return &v2pb.Cluster{
+		ObjectMeta: v1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec: v2pb.ClusterSpec{
+			Cluster: &v2pb.ClusterSpec_Kubernetes{
+				Kubernetes: &v2pb.KubernetesSpec{
+					Rest: &v2pb.ConnectionSpec{
+						Host:      "https://k8s-cluster.example.com",
+						Port:      "443",
+						CaDataTag: caTag,
+						TokenTag:  tokenTag,
+					},
+				},
+			},
+		},
+	}
+}
+
+func credentialSecret(name, namespace, key, value string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		Data:       map[string][]byte{key: []byte(value)},
+	}
+}
+
+func TestESOProviderGetClusterClientAuth(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t,
+		credentialSecret("ca-secret", "ma-secrets", "cadata", "fake-ca-data"),
+		credentialSecret("token-secret", "ma-secrets", "token", "fake-token-data"),
+	)
+	provider := NewESOProvider(fakeClientSet, ESOConfig{Namespace: "ma-secrets"}, nil)
+
+	auth, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	require.Equal(t, ClientAuth{
+		CertificateAuthorityData: "fake-ca-data",
+		ClientTokenData:          "fake-token-data",
+	}, auth)
+}
+
+func TestESOProviderDefaultNamespace(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t,
+		credentialSecret("ca-secret", "default", "cadata", "fake-ca-data"),
+		credentialSecret("token-secret", "default", "token", "fake-token-data"),
+	)
+	provider := NewESOProvider(fakeClientSet, ESOConfig{}, nil)
+
+	auth, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	require.Equal(t, "fake-ca-data", auth.CertificateAuthorityData)
+}
+
+func TestESOProviderOperatorAbsent(t *testing.T) {
+	fakeClientSet := fakek8sclient.NewSimpleClientset()
+	provider := NewESOProvider(fakeClientSet, ESOConfig{}, nil)
+
+	_, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "external secrets operator does not appear to be installed")
+	require.Contains(t, err.Error(), esoAPIGroup)
+}
+
+func TestESOProviderMissingSecretGuidance(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t)
+	provider := NewESOProvider(fakeClientSet, ESOConfig{Namespace: "ma-secrets"}, nil)
+
+	_, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("missing-ca", "missing-token"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "check that the ExternalSecret exists and has synced")
+	require.Contains(t, err.Error(), "ma-secrets/missing-ca")
+}
+
+func TestESOProviderUnsupportedClusterType(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t)
+	provider := NewESOProvider(fakeClientSet, ESOConfig{}, nil)
+
+	cluster := &v2pb.Cluster{
+		ObjectMeta: v1.ObjectMeta{Name: "test-cluster", Namespace: "default"},
+		Spec:       v2pb.ClusterSpec{},
+	}
+	_, err := provider.GetClusterClientAuth(context.Background(), cluster)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not supported")
+}
+
+func TestESOProviderGetSecretsForDataStore(t *testing.T) {
+	provider := NewESOProvider(newFakeClientSetWithESO(t), ESOConfig{}, nil)
+	data, err := provider.GetSecretsForDataStore(context.Background(), nil, nil)
+	require.NoError(t, err)
+	require.Nil(t, data)
+}
+
+func TestNewSelectsProviderFromConfig(t *testing.T) {
+	fakeClientSet := fakek8sclient.NewSimpleClientset()
+
+	tests := []struct {
+		name         string
+		cfg          Config
+		expectSample bool
+		expectESO    bool
+		expectErr    string
+	}{
+		{name: "default is sample", cfg: Config{}, expectSample: true},
+		{name: "explicit sample", cfg: Config{Provider: ProviderSample}, expectSample: true},
+		{name: "eso", cfg: Config{Provider: ProviderESO}, expectESO: true},
+		{name: "unknown provider", cfg: Config{Provider: "vault"}, expectErr: "unknown secrets.provider"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := New(Params{ClientSet: fakeClientSet, Cfg: tt.cfg})
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.expectSample {
+				require.IsType(t, Provider{}, result.SecretProvider)
+			}
+			if tt.expectESO {
+				require.IsType(t, &ESOProvider{}, result.SecretProvider)
+			}
+		})
+	}
+}
+
+func TestESOProviderCachesOperatorCheck(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t,
+		credentialSecret("ca-secret", "default", "cadata", "fake-ca-data"),
+		credentialSecret("token-secret", "default", "token", "fake-token-data"),
+	)
+	provider := NewESOProvider(fakeClientSet, ESOConfig{}, nil)
+
+	_, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.NoError(t, err)
+	// Second call takes the cached-verification path.
+	_, err = provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.NoError(t, err)
+}
+
+func TestESOProviderGenericGetError(t *testing.T) {
+	fakeClientSet := newFakeClientSetWithESO(t)
+	fakeClientSet.(*fakek8sclient.Clientset).PrependReactor("get", "secrets",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("api server unavailable")
+		})
+	provider := NewESOProvider(fakeClientSet, ESOConfig{}, nil)
+
+	_, err := provider.GetClusterClientAuth(context.Background(), kubeCluster("ca-secret", "token-secret"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "api server unavailable")
+	require.NotContains(t, err.Error(), "ExternalSecret")
+}

--- a/go/components/jobs/common/secrets/module.go
+++ b/go/components/jobs/common/secrets/module.go
@@ -1,9 +1,14 @@
 package secrets
 
-import "go.uber.org/fx"
+import (
+	"go.uber.org/fx"
+
+	baseconfig "github.com/michelangelo-ai/michelangelo/go/base/config"
+)
 
 // Module provides the common objects
 var Module = fx.Module("secrets",
+	fx.Provide(baseconfig.ProvideConfig[Config](configKey)),
 	fx.Provide(New),
 	fx.Provide(NewInClusterClientSet),
 )

--- a/go/components/jobs/common/secrets/secrets.go
+++ b/go/components/jobs/common/secrets/secrets.go
@@ -26,9 +26,10 @@ type SecretProvider interface {
 // Provider implements the SecretProvider interface.
 //
 // NOTE: This is a SAMPLE IMPLEMENTATION that stores secrets in the MA control plane K8s Cluster.
-// This is NOT recommended for production use. For real deployments, use external secret
-// management systems (e.g., HashiCorp Vault, AWS Secrets Manager) or explore utilities
-// designed for sandbox/testing purposes.
+// This is NOT recommended for production use. For real deployments, set
+// `secrets.provider: eso` to use the External Secrets Operator backed
+// ESOProvider, which sources credentials from an external secret manager
+// (e.g., HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager).
 type Provider struct {
 	k8sClusterClient kubernetes.Interface
 	logger           *zap.Logger
@@ -52,6 +53,7 @@ type Params struct {
 
 	ClientSet kubernetes.Interface `name:"inClusterClientSet"`
 	Logger    *zap.Logger
+	Cfg       Config `optional:"true"`
 }
 
 type InClusterClientSet struct {
@@ -86,13 +88,26 @@ type Result struct {
 	SecretProvider SecretProvider
 }
 
-// New provides new Secrets generator
-func New(p Params) Result {
-	return Result{
-		SecretProvider: Provider{
-			k8sClusterClient: p.ClientSet,
-			logger:           p.Logger,
-		},
+// New provides the SecretProvider selected by `secrets.provider`: the
+// sample control-plane provider by default, or the External Secrets
+// Operator backed provider when configured as "eso".
+func New(p Params) (Result, error) {
+	switch p.Cfg.Provider {
+	case "", ProviderSample:
+		return Result{
+			SecretProvider: Provider{
+				k8sClusterClient: p.ClientSet,
+				logger:           p.Logger,
+			},
+		}, nil
+	case ProviderESO:
+		return Result{
+			SecretProvider: NewESOProvider(p.ClientSet, p.Cfg.ESO, p.Logger),
+		}, nil
+	default:
+		return Result{}, fmt.Errorf(
+			"unknown secrets.provider %q: must be %q or %q",
+			p.Cfg.Provider, ProviderSample, ProviderESO)
 	}
 }
 

--- a/helm/michelangelo/README.md
+++ b/helm/michelangelo/README.md
@@ -250,6 +250,8 @@ Top-level keys. See [`values.yaml`](./values.yaml) for the full annotated schema
 | `objectStorage.accessKeyId` | string | `""` | conditional | Required unless `objectStorage.existingSecret` is set. |
 | `objectStorage.secretAccessKey` | string | `""` | conditional | Required unless `objectStorage.existingSecret` is set. |
 | `objectStorage.existingSecret` | string | `""` | no | Name of a pre-existing Secret with `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys. Takes precedence over the inline keys. |
+| `secretsProvider.type` | string | `sample` | no | Secret provider for remote-cluster credentials: `sample` (control-plane Secrets, sandbox/testing) or `eso` (Secrets synced by the External Secrets Operator, installed separately). |
+| `secretsProvider.esoNamespace` | string | `""` | no | Namespace where operator-synced credential Secrets live (`type=eso` only). Defaults to `default`. |
 | `workflow.engine` | string | `cadence` | yes | `cadence` or `temporal`. Mutually exclusive — selects which worker config block renders. |
 | `workflow.endpoint` | string | `""` | **yes** | Workflow engine address (e.g. `cadence-frontend:7833`, `temporal-frontend:7233`). |
 | `workflow.domain` | string | `default` | no | Cadence domain or Temporal namespace. |

--- a/helm/michelangelo/templates/core/controllermgr-configmap.yaml
+++ b/helm/michelangelo/templates/core/controllermgr-configmap.yaml
@@ -25,6 +25,13 @@ data:
       awsSecretAccessKey: ${AWS_SECRET_ACCESS_KEY}
       awsEndpointUrl: {{ required "objectStorage.endpoint is required — see helm/michelangelo/README.md#values-reference" .Values.objectStorage.endpoint | quote }}
       secure: {{ .Values.objectStorage.secure }}
+    {{- if ne .Values.secretsProvider.type "sample" }}
+
+    secrets:
+      provider: {{ .Values.secretsProvider.type | quote }}
+      eso:
+        namespace: {{ .Values.secretsProvider.esoNamespace | default "default" | quote }}
+    {{- end }}
 
     metadataStorage:
       enableMetadataStorage: {{ .Values.controllermgr.metadataStorage.enable }}

--- a/helm/michelangelo/templates/validations.yaml
+++ b/helm/michelangelo/templates/validations.yaml
@@ -8,3 +8,6 @@ This file renders to empty YAML when all checks pass.
 {{- if and .Values.monitoring.enabled (not .Values.controllermgr.enabled) -}}
 {{- fail "monitoring.enabled requires controllermgr.enabled=true — the controller manager is the only component exposing a /metrics endpoint. See helm/michelangelo/README.md." -}}
 {{- end -}}
+{{- if not (has .Values.secretsProvider.type (list "sample" "eso")) -}}
+{{- fail (printf "secretsProvider.type must be 'sample' or 'eso', got: %s. See helm/michelangelo/README.md." .Values.secretsProvider.type) -}}
+{{- end -}}

--- a/helm/michelangelo/values.yaml
+++ b/helm/michelangelo/values.yaml
@@ -75,6 +75,24 @@ objectStorage:
   existingSecret: ""
 
 # -----------------------------------------------------------------------------
+# Secret provider for remote-cluster credentials (jobs engine and
+# inference-server client factory). Unrelated to `metadataStorage` /
+# `objectStorage` credentials above.
+# -----------------------------------------------------------------------------
+secretsProvider:
+  # "sample" (default) reads credential Secrets from the control-plane
+  # cluster and is intended for sandbox and testing.
+  # "eso" reads Secrets materialized by the External Secrets Operator
+  # (installed separately) from ExternalSecret resources you manage, synced
+  # from an external store such as Vault, AWS Secrets Manager, or GCP
+  # Secret Manager.
+  type: sample
+
+  # Namespace where operator-synced credential Secrets live. Only used with
+  # type=eso. Defaults to "default", matching the sample provider.
+  esoNamespace: ""
+
+# -----------------------------------------------------------------------------
 # Workflow engine — Cadence or Temporal. Required by worker and apiserver.
 # -----------------------------------------------------------------------------
 workflow:


### PR DESCRIPTION
Stacked on #1864 -- review only the last commit (`helm: expose secrets provider selection via secretsProvider values`); the earlier commit is #1864's.

**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Follow-up to #1864 (ESO-backed secret provider): exposes provider selection through the chart, so operators can switch off the sample provider without hand-editing ConfigMaps.

```yaml
secretsProvider:
  type: eso                  # "sample" (default) or "eso"
  esoNamespace: ma-secrets   # optional; defaults to "default"
```

- `values.yaml` gains a documented `secretsProvider` block (default `sample` -- rendered output is byte-identical to the current chart when untouched).
- The controllermgr ConfigMap conditionally renders the `secrets:` config section when a non-default provider is selected. Only controllermgr gets it: both credential consumers (jobs engine, inference client factory) run in that binary.
- `templates/validations.yaml` fails fast at template time on unknown provider types, matching the existing cadence/temporal guard.
- Chart README values-reference rows and an operator-guide section (including the note that ESO itself is installed separately and `ExternalSecret` resources are operator-managed).
- Two new CI template checks in the helm-lint workflow: an eso-enabled render and a negative test proving the fail-fast guard fires.

**Why?**

#1864 adds the provider behind config, but without chart plumbing an operator has to hand-edit the controllermgr ConfigMap to select it. This wires the selection through values the same way the chart's other optional backends are selected, with a template-time guard so a typo fails the deploy rather than silently falling back.

**How did you test it?**

- `helm lint` clean.
- Baseline, eso-enabled, and fail-fast renders all verified locally with the exact commands the new CI steps run.
- Default render is byte-identical to the #1864 branch render (verified by diffing full `helm template` output) -- this PR is a no-op unless `secretsProvider.type` is set.
- eso-enabled render parsed structurally: exactly one ConfigMap (controllermgr) carries the `secrets:` block, with the namespace defaulting to `default` when `esoNamespace` is unset.
- Unknown type (`--set secretsProvider.type=vault`) fails at template time with a clear message; the cadence/temporal guard still fires.

**Potential risks**

- None for existing installations: with `secretsProvider` unset the rendered chart is byte-identical to today's.
- Known overlap with #1921 (GCS chart exposure): both append to `values.yaml` and the README values table; whichever merges second rebases trivially.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Helm: new optional `secretsProvider` block selects the secrets backend (`sample` default, `eso`), with a template-time guard on unknown types.

**Documentation Changes**

Chart README values-reference rows and a new operator-guide section on enabling the ESO provider.