### PR TITLE
fix(ui): show PipelineRuns on the Pipeline Detail page

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -74,6 +74,11 @@ const (
 	// SourcePipelineManifestTypeLabelName is the Kubernetes label key that identifies
 	// the pipeline manifest type (e.g. PIPELINE_MANIFEST_TYPE_ASL).
 	SourcePipelineManifestTypeLabelName = "pipeline.michelangelo/PipelineManifestType"
+
+	// PipelineNameLabelName is the Kubernetes label key that identifies the
+	// owning Pipeline's metadata.name on a PipelineRun, used to filter runs
+	// down to a single pipeline (e.g. on the Pipeline detail page).
+	PipelineNameLabelName = "pipelinerun.michelangelo/pipeline-name"
 )
 
 // DefaultContextTimeout defines the default timeout for the context

--- a/go/components/pipelinerun/apihook/apihook.go
+++ b/go/components/pipelinerun/apihook/apihook.go
@@ -97,6 +97,12 @@ func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreatePipelineRun
 		api.StampSourcePipelineTypeLabelOnCreate(request.PipelineRun, pipelineType.String())
 	}
 
+	// setIfAbsent: trigger-created runs already carry this label (stamped by
+	// the trigger workflow before CreatePipelineRun is called); this covers
+	// every other creation path (e.g. the manual "Run" action) so the
+	// Pipeline detail page's runs list can filter on it uniformly.
+	setIfAbsent(request.PipelineRun, api.PipelineNameLabelName, pipeline.Name)
+
 	return cascadedelete.StampOwnerRefOnCreate(ctx, a.logger, a.scheme, request.PipelineRun, pipeline)
 }
 

--- a/go/components/pipelinerun/apihook/apihook_test.go
+++ b/go/components/pipelinerun/apihook/apihook_test.go
@@ -629,3 +629,30 @@ func TestBeforeCreate_StampsSourcePipelineTypeLabel(t *testing.T) {
 	assert.Equal(t, "PIPELINE_TYPE_TRAIN",
 		request.PipelineRun.GetLabels()[api.SourcePipelineTypeLabelName])
 }
+
+func TestBeforeCreate_StampsPipelineNameLabel(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	}
+	hook := setUpHook(t, live)
+
+	request := newPipelineRefRequest("test-pipeline")
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	assert.Equal(t, "test-pipeline",
+		request.PipelineRun.GetLabels()[api.PipelineNameLabelName])
+}
+
+func TestBeforeCreate_DoesNotOverwriteExistingPipelineNameLabel(t *testing.T) {
+	live := &v2.Pipeline{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pipeline", Namespace: testNamespace},
+	}
+	hook := setUpHook(t, live)
+
+	request := newPipelineRefRequest("test-pipeline")
+	request.PipelineRun.ObjectMeta.Labels = map[string]string{
+		api.PipelineNameLabelName: "pre-stamped-value",
+	}
+	require.NoError(t, hook.BeforeCreate(context.Background(), request))
+	assert.Equal(t, "pre-stamped-value",
+		request.PipelineRun.GetLabels()[api.PipelineNameLabelName])
+}

--- a/go/worker/workflows/trigger/cron_trigger_workflows.go
+++ b/go/worker/workflows/trigger/cron_trigger_workflows.go
@@ -73,8 +73,10 @@ var (
 	// PipelineManifestTypeLabel is to indicate the manifest type of this pipeline
 	PipelineManifestTypeLabel = "pipeline.michelangelo/PipelineManifestType"
 
-	// PipelineNameLabel stores the pipeline name for filtering pipeline runs
-	PipelineNameLabel = "pipelinerun.michelangelo/pipeline-name"
+	// PipelineNameLabel stores the pipeline name for filtering pipeline runs.
+	// Kept in sync with mgapi.PipelineNameLabelName, which apihook.go also
+	// stamps for non-trigger-created runs.
+	PipelineNameLabel = mgapi.PipelineNameLabelName
 
 	// activityOptionsDefault is the default activity options for the trigger workflow
 	activityOptionsDefault = workflow.ActivityOptions{

--- a/javascript/packages/core/config/entities/pipeline/detail.ts
+++ b/javascript/packages/core/config/entities/pipeline/detail.ts
@@ -23,8 +23,11 @@ export const PIPELINE_DETAIL_CONFIG: DetailViewConfig = {
         service: 'pipelineRun',
         serviceOptions: {
           listOptions: {
-            // Filter runs to only those belonging to the current pipeline
-            labelSelector: 'pipeline.michelangelo/name=${page.metadata.name}',
+            // Filter runs to only those belonging to the current pipeline. Stamped by
+            // apiHook.BeforeCreate (go/components/pipelinerun/apihook/apihook.go) on every
+            // PipelineRun creation path, including trigger-created runs (already set before
+            // creation by the trigger workflow, and left alone there).
+            labelSelector: 'pipelinerun.michelangelo/pipeline-name=${page.metadata.name}',
           },
         },
       },

--- a/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
+++ b/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
@@ -165,10 +165,8 @@ export const ResumeRunFields = ({ pipelineName }: { pipelineName: string }) => {
  * The pipeline filter is repeated here even though {@link buildPipelineCriterion} already
  * asks for it server-side: `ListOptionsExt` is honored only when metadata storage is
  * enabled and is otherwise silently ignored, so relying on it alone would widen the picker
- * to other pipelines' runs rather than narrowing it. (The label selector the pipeline
- * detail page uses, `pipeline.michelangelo/name`, is written by nothing in the platform,
- * so it is not an alternative.) This pass also does the terminal-state gating, newest-first
- * ordering, and cap, none of which the criterion expresses.
+ * to other pipelines' runs rather than narrowing it. This pass also does the terminal-state
+ * gating, newest-first ordering, and cap, none of which the criterion expresses.
  */
 function buildSourceRunOptions(
   items: PipelineRunSummary[] | undefined,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

The Pipeline Detail page's Runs tab and PipelineRun creation
disagreed on which label identifies a run's owning pipeline, so runs
never showed up. Stamp that label consistently on every creation
path, and point the frontend at the same key.

<!-- Tell your future self why have you made these changes -->
**Why?**

Trigger-created runs were labeled differently than what the frontend
queried for, and manually-created runs (the common "Run" button path)
got no pipeline-name label at all. Either way, the Runs tab came up
empty.

I considered a `fieldSelector` on `spec.pipeline.name` instead of a
label, since `PipelineRun` has a proto index annotation on that
field. But field selectors only resolve through the metadata-storage
list path, which is off by default — so they'd silently fail to
filter in most deployments (the same class of bug #1973 hit). A label
works regardless of storage backend.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added two Go unit tests covering the new stamping behavior; existing
Go and JS test suites pass, along with `go build`, `yarn typecheck`,
and `yarn lint`.

I also verified end-to-end in a local sandbox: reproduced the empty
Runs tab against the unfixed apiserver
(`02-runs-still-empty-before-label-fix.png`), confirmed the frontend
fix alone by manually labeling a run
(`03-runs-visible-after-label-fix.png`), then deployed the real fix
and confirmed a run created through the UI is auto-labeled and shows
up with no manual intervention
(`05-real-run-visible-full-e2e.png`).

**Potential risks**

Low — the label is additive (never overwrites an existing value) and
follows the same stamping pattern already used for `ownerRef` and
`SourcePipelineType` on the same hook. PipelineRuns created before
this fix won't be backfilled.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A