### PR TITLE
feat(ui): add Last Updated and Environment columns to pipeline run list

### DIFF
--- a/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
@@ -35,6 +35,7 @@ describe('Run list page', () => {
       'Pipeline run name',
       'Pipeline',
       'Last Updated',
+      'Created',
       'Environment',
       'Started by',
       'State',
@@ -59,7 +60,10 @@ describe('Run list page', () => {
                       'michelangelo/UpdateTimestamp': '1700000000000000',
                       'michelangelo/environment': 'production',
                     },
-                    creationTimestamp: { seconds: 1650000000 },
+                    // Distinct from run-without-labels' creationTimestamp below so this row's
+                    // Created value (which always reads creationTimestamp) doesn't collide with
+                    // the other row's Last Updated fallback (which also reads creationTimestamp).
+                    creationTimestamp: { seconds: 1660000000 },
                   },
                   spec: { actor: { name: 'jsmith' }, pipeline: { name: 'prediction-pipeline' } },
                   status: { state: 3 },
@@ -83,10 +87,13 @@ describe('Run list page', () => {
     expect(screen.getByText('Production')).toBeInTheDocument();
     // The UpdateTimestamp label (1700000000 seconds) is used over creationTimestamp.
     expect(screen.getByText('2023/11/14 22:13:20 (UTC)')).toBeInTheDocument();
+    // Created always reads creationTimestamp (1660000000 seconds), independent of Last Updated.
+    expect(screen.getByText('2022/08/08 23:06:40 (UTC)')).toBeInTheDocument();
 
     expect(screen.getByRole('link', { name: 'run-without-labels' })).toBeInTheDocument();
-    // No UpdateTimestamp label: falls back to creationTimestamp (1650000000 seconds).
-    expect(screen.getByText('2022/04/15 05:20:00 (UTC)')).toBeInTheDocument();
+    // No UpdateTimestamp label: Last Updated falls back to creationTimestamp (1650000000
+    // seconds), the same value Created reads directly — both cells render this text.
+    expect(screen.getAllByText('2022/04/15 05:20:00 (UTC)')).toHaveLength(2);
     // No environment label: renders no Environment text at all.
     expect(screen.queryByText('Development')).not.toBeInTheDocument();
     expect(screen.queryByText('Testing')).not.toBeInTheDocument();

--- a/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from '#core/router/entity-detail-route';
+import { PhaseListRoute } from '#core/router/phase-list-route';
 import { buildWrapper } from '#core/test/wrappers/build-wrapper';
 import { getErrorProviderWrapper } from '#core/test/wrappers/get-error-provider-wrapper';
 import { getRouterWrapper } from '#core/test/wrappers/get-router-wrapper';
@@ -9,6 +11,87 @@ import {
   createQueryMockRouter,
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
+import { getUserProviderWrapper } from '#core/test/wrappers/get-user-provider-wrapper';
+
+describe('Run list page', () => {
+  it('renders the column headers in order', async () => {
+    render(
+      <PhaseListRoute phases={{ train: TRAIN_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/train/runs' }),
+        getUserProviderWrapper(),
+        getServiceProviderWrapper({
+          request: vi.fn().mockResolvedValue({ pipelineRunList: { items: [] } }),
+        }),
+      ])
+    );
+
+    const headers = await screen.findAllByRole('columnheader');
+    // Trailing columns with no text content are table chrome (e.g. a row-actions column),
+    // not a named data column, so they're excluded from the ordering assertion.
+    const headerLabels = headers.map((header) => header.textContent).filter(Boolean);
+    expect(headerLabels).toEqual([
+      'Pipeline run name',
+      'Pipeline',
+      'Last Updated',
+      'Environment',
+      'Started by',
+      'State',
+    ]);
+  });
+
+  it('renders Last Updated and Environment values, with fallbacks', async () => {
+    render(
+      <PhaseListRoute phases={{ train: TRAIN_PHASE }} />,
+      buildWrapper([
+        getErrorProviderWrapper(),
+        getRouterWrapper({ location: '/myproject/train/runs' }),
+        getUserProviderWrapper(),
+        getServiceProviderWrapper({
+          request: vi.fn().mockResolvedValue({
+            pipelineRunList: {
+              items: [
+                {
+                  metadata: {
+                    name: 'run-with-labels',
+                    labels: {
+                      'michelangelo/UpdateTimestamp': '1700000000000000',
+                      'michelangelo/environment': 'production',
+                    },
+                    creationTimestamp: { seconds: 1650000000 },
+                  },
+                  spec: { actor: { name: 'jsmith' }, pipeline: { name: 'prediction-pipeline' } },
+                  status: { state: 3 },
+                },
+                {
+                  metadata: {
+                    name: 'run-without-labels',
+                    creationTimestamp: { seconds: 1650000000 },
+                  },
+                  spec: { actor: { name: 'jsmith' }, pipeline: { name: 'prediction-pipeline' } },
+                  status: { state: 3 },
+                },
+              ],
+            },
+          }),
+        }),
+      ])
+    );
+
+    expect(await screen.findByRole('link', { name: 'run-with-labels' })).toBeInTheDocument();
+    expect(screen.getByText('Production')).toBeInTheDocument();
+    // The UpdateTimestamp label (1700000000 seconds) is used over creationTimestamp.
+    expect(screen.getByText('2023/11/14 22:13:20 (UTC)')).toBeInTheDocument();
+
+    expect(screen.getByRole('link', { name: 'run-without-labels' })).toBeInTheDocument();
+    // No UpdateTimestamp label: falls back to creationTimestamp (1650000000 seconds).
+    expect(screen.getByText('2022/04/15 05:20:00 (UTC)')).toBeInTheDocument();
+    // No environment label: renders no Environment text at all.
+    expect(screen.queryByText('Development')).not.toBeInTheDocument();
+    expect(screen.queryByText('Testing')).not.toBeInTheDocument();
+  });
+});
 
 describe('Run detail page', () => {
   describe('configuration tab', () => {

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -1,5 +1,7 @@
 import { CellType } from '#core/components/cell/constants';
-import { SHARED_RUN_CELL_CONFIG } from './shared';
+import { getCrdLastUpdatedSeconds } from '#core/utils/crd-utils';
+import { readEnvironmentLabel } from '#core/utils/environment-utils';
+import { RUN_PIPELINE_COLUMN, RUN_STARTED_BY_COLUMN, RUN_STATE_COLUMN } from './shared';
 
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
@@ -7,7 +9,7 @@ import type { ListViewConfig } from '#core/components/views/types';
 export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
   {
     id: 'metadata.name',
-    label: 'Name',
+    label: 'Pipeline run name',
     items: [
       {
         id: 'metadata.name',
@@ -19,7 +21,33 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
       },
     ],
   },
-  ...SHARED_RUN_CELL_CONFIG,
+  RUN_PIPELINE_COLUMN,
+  {
+    id: 'metadata',
+    label: 'Last Updated',
+    type: CellType.DATE,
+    accessor: (data: unknown) => {
+      // cast: accessor receives unknown data; narrowing to expected proto shape for property
+      // access; see #1425
+      const row = data as {
+        metadata?: { labels?: Record<string, string>; creationTimestamp?: { seconds: number } };
+      };
+      return getCrdLastUpdatedSeconds(row);
+    },
+  },
+  {
+    id: 'metadata.labels',
+    label: 'Environment',
+    type: CellType.TEXT,
+    accessor: (data: unknown) => {
+      // cast: accessor receives unknown data; narrowing to expected proto shape for property
+      // access; see #1425
+      const labels = (data as { metadata?: { labels?: Record<string, string> } })?.metadata?.labels;
+      return readEnvironmentLabel(labels) || null;
+    },
+  },
+  RUN_STARTED_BY_COLUMN,
+  RUN_STATE_COLUMN,
 ];
 
 export const RUN_LIST_CONFIG: ListViewConfig<object> = {

--- a/javascript/packages/core/config/entities/run/list.ts
+++ b/javascript/packages/core/config/entities/run/list.ts
@@ -1,7 +1,12 @@
 import { CellType } from '#core/components/cell/constants';
 import { getCrdLastUpdatedSeconds } from '#core/utils/crd-utils';
 import { readEnvironmentLabel } from '#core/utils/environment-utils';
-import { RUN_PIPELINE_COLUMN, RUN_STARTED_BY_COLUMN, RUN_STATE_COLUMN } from './shared';
+import {
+  RUN_CREATED_COLUMN,
+  RUN_PIPELINE_COLUMN,
+  RUN_STARTED_BY_COLUMN,
+  RUN_STATE_COLUMN,
+} from './shared';
 
 import type { ColumnConfig } from '#core/components/table/types/column-types';
 import type { ListViewConfig } from '#core/components/views/types';
@@ -35,6 +40,7 @@ export const PIPELINE_RUN_CELL_CONFIG: ColumnConfig<object>[] = [
       return getCrdLastUpdatedSeconds(row);
     },
   },
+  RUN_CREATED_COLUMN,
   {
     id: 'metadata.labels',
     label: 'Environment',

--- a/javascript/packages/core/config/entities/run/shared.ts
+++ b/javascript/packages/core/config/entities/run/shared.ts
@@ -55,37 +55,53 @@ export const RUN_STATE_COLOR_MAP: Record<number, TagColor> = {
   6: 'gray',
 };
 
+/** Created-date cell, shared between the run list and detail pages. */
+export const RUN_CREATED_COLUMN: Cell = {
+  id: 'metadata.creationTimestamp.seconds',
+  label: 'Created',
+  type: CellType.DATE,
+};
+
+/** Pipeline (and revision) cell, shared between the run list and detail pages. */
+export const RUN_PIPELINE_COLUMN: Cell = {
+  id: 'spec.pipeline.name',
+  label: 'Pipeline',
+  items: [
+    {
+      id: 'spec.pipeline.name',
+      type: CellType.TEXT,
+    },
+    {
+      id: 'spec.revision.name',
+      type: CellType.DESCRIPTION,
+    },
+  ],
+};
+
+/** Run actor cell, shared between the run list and detail pages. */
+export const RUN_STARTED_BY_COLUMN: Cell = {
+  id: 'spec.actor.name',
+  label: 'Started by',
+  type: CellType.TEXT,
+};
+
+/** Run state cell, shared between the run list and detail pages. */
+export const RUN_STATE_COLUMN: Cell = {
+  id: 'status.state',
+  label: 'State',
+  type: CellType.STATE,
+  stateTextMap: RUN_STATE_TEXT_MAP,
+  stateColorMap: RUN_STATE_COLOR_MAP,
+};
+
 /**
  * Cell configurations rendered for Pipeline Runs:
  *  - Columns for list view
  *  - Header metadata for detail view
  */
 export const SHARED_RUN_CELL_CONFIG: Cell[] = [
-  { id: 'metadata.creationTimestamp.seconds', label: 'Created', type: CellType.DATE },
-  {
-    id: 'spec.pipeline.name',
-    label: 'Pipeline',
-    items: [
-      {
-        id: 'spec.pipeline.name',
-        type: CellType.TEXT,
-      },
-      {
-        id: 'spec.revision.name',
-        type: CellType.DESCRIPTION,
-      },
-    ],
-  },
-  {
-    id: 'spec.actor.name',
-    label: 'Started by',
-    type: CellType.TEXT,
-  },
-  {
-    id: 'status.state',
-    label: 'State',
-    type: CellType.STATE,
-    stateTextMap: RUN_STATE_TEXT_MAP,
-    stateColorMap: RUN_STATE_COLOR_MAP,
-  },
+  RUN_CREATED_COLUMN,
+  RUN_PIPELINE_COLUMN,
+  RUN_STARTED_BY_COLUMN,
+  RUN_STATE_COLUMN,
 ];

--- a/javascript/packages/core/utils/crd-utils.ts
+++ b/javascript/packages/core/utils/crd-utils.ts
@@ -1,4 +1,5 @@
-const UPDATE_TIMESTAMP_LABEL_KEY = 'michelangelo/SpecUpdateTimestamp';
+const SPEC_UPDATE_TIMESTAMP_LABEL_KEY = 'michelangelo/SpecUpdateTimestamp';
+const UPDATE_TIMESTAMP_LABEL_KEY = 'michelangelo/UpdateTimestamp';
 const MICROSECONDS_PER_SECOND = 1_000_000;
 
 /**
@@ -35,6 +36,34 @@ export const K8S_NAME_RULES_MESSAGE =
  * }) // 1650000000 (label absent, falls back to creation time)
  */
 export function getCrdUpdatedSeconds(data: {
+  metadata?: { labels?: Record<string, string>; creationTimestamp?: { seconds: number } };
+}): number | undefined {
+  const label = data.metadata?.labels?.[SPEC_UPDATE_TIMESTAMP_LABEL_KEY];
+  if (label) return Number(label) / MICROSECONDS_PER_SECOND;
+  return data.metadata?.creationTimestamp?.seconds;
+}
+
+/**
+ * Resolves the epoch-seconds timestamp to display as an entity's "last updated" time,
+ * counting any update — not just a spec change — unlike {@link getCrdUpdatedSeconds}.
+ *
+ * Some CRD-backed entities (e.g. a pipeline run) have a `status` that changes continuously
+ * while their `spec` is effectively immutable after creation. For those, `getCrdUpdatedSeconds`'s
+ * spec-only label would render a value frozen at creation time for nearly every row, which
+ * defeats the point of a "last updated" column. This instead reads the `michelangelo/UpdateTimestamp`
+ * metadata label, which the apiserver refreshes on every update to the resource, with the same
+ * `metadata.creationTimestamp` fallback for rows that predate the label or have never been updated.
+ *
+ * @example
+ * getCrdLastUpdatedSeconds({
+ *   metadata: { labels: { 'michelangelo/UpdateTimestamp': '1700000000000000' } },
+ * }) // 1700000000
+ *
+ * getCrdLastUpdatedSeconds({
+ *   metadata: { creationTimestamp: { seconds: 1650000000 } },
+ * }) // 1650000000 (label absent, falls back to creation time)
+ */
+export function getCrdLastUpdatedSeconds(data: {
   metadata?: { labels?: Record<string, string>; creationTimestamp?: { seconds: number } };
 }): number | undefined {
   const label = data.metadata?.labels?.[UPDATE_TIMESTAMP_LABEL_KEY];


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**
- Reordered/expanded the pipeline run list's columns from `Name, Created, Pipeline, Started by, State` to `Pipeline run name, Pipeline, Last Updated, Created, Environment, Started by, State`.
- Renamed the "Name" column to "Pipeline run name".
- Added a "Last Updated" column backed by a new `getCrdLastUpdatedSeconds()` utility (sibling to the existing `getCrdUpdatedSeconds()`) that reads the `michelangelo/UpdateTimestamp` label — set on *any* update to the resource, not just spec changes — with the same `creationTimestamp` fallback. A pipeline run's `status` changes continuously as steps execute while its `spec` is effectively immutable after creation, so the existing spec-only utility would render a value frozen at creation time for nearly every run.
- Added an "Environment" column reusing the existing `readEnvironmentLabel()` utility.
- Kept the existing "Created" column, moved to sit immediately after "Last Updated", reusing the `RUN_CREATED_COLUMN` constant now exported from `shared.ts`.
- Refactored `run/shared.ts` to export each of `SHARED_RUN_CELL_CONFIG`'s four entries individually (`RUN_CREATED_COLUMN`, `RUN_PIPELINE_COLUMN`, `RUN_STARTED_BY_COLUMN`, `RUN_STATE_COLUMN`), with `SHARED_RUN_CELL_CONFIG` itself composed from those same exports so its value/order is unchanged — this lets the list page pick an interleaved subset of shared columns without touching the shared array's contents (still used as-is by the run detail page and by two other entities' sub-tables).

**Why?**
The run list's column set didn't surface when a run was last touched (beyond its creation time) or which environment it ran in, both of which are useful at a glance when scanning a list of runs. Created was kept (rather than dropped) since it remains useful alongside the new Last Updated column, placed right after it.

**How did you test it?**
- `run.test.tsx`'s `describe('Run list page', ...)` block: one test asserting all 7 column headers render in the target order, and one test asserting Last Updated falls back to `creationTimestamp` when the update-timestamp label is absent, Created always renders from `creationTimestamp`, and Environment renders blank when its label is absent.
- Confirmed the existing `Run detail page` tests still pass unmodified after the `shared.ts` refactor.
- `yarn test`, `yarn typecheck`, `yarn lint`, and `prettier --check` all pass for the changed files (pre-existing failures elsewhere in the repo are unrelated — they come from generated protobuf/RPC client files that aren't checked in, reproducible on a clean checkout of `main` with no changes from this PR).

**Potential risks**
None beyond the column reorder itself — Created is retained, so no downstream consumer relying on its presence is affected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**
N/A

**Documentation Changes**
N/A
