### PR TITLE
fix(python): accept inference-multicluster in sandbox demo guard

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -1233,7 +1233,7 @@ def _assert_sandbox_cluster_running():
 def _create_demo_crs(ns: argparse.Namespace):
     """Create demo Custom Resources (CRs) for the sandbox environment."""
     assert ns
-    if ns.demo_action != "pipeline" and ns.demo_action != "inference":
+    if ns.demo_action not in ("pipeline", "inference", "inference-multicluster"):
         raise ValueError(f"Unsupported demo action: {ns.demo_action}")
 
     _assert_sandbox_cluster_running()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Widened the early validation guard in `_create_demo_crs` to include `inference-multicluster`:

```python
if ns.demo_action not in ("pipeline", "inference", "inference-multicluster"):
    raise ValueError(f"Unsupported demo action: {ns.demo_action}")
```

**Why?**

`ma sandbox demo inference-multicluster` is currently broken on `main`. It fails with `ValueError: Unsupported demo action: inference-multicluster` before doing any work.

The failure is confusing because argparse accepts the subcommand fine — the guard at the top of `_create_demo_crs` rejects it a moment later, so the dispatch branch that actually handles it (`elif ns.demo_action == "inference-multicluster"`) is unreachable dead code.

#1175 added the multi-cluster demo and correctly widened this guard. #1715 (`feat(python): add ma sandbox snapshot create/restore`) reverted that one line back to its pre-#1175 two-way form, while leaving the subparser registration and the dispatch branch untouched. That PR is otherwise unrelated to demos, so this looks like a stale-branch conflict resolution rather than an intentional change. This restores the line to what #1175 had.

**How did you test it?**

- Confirmed `_create_demo_crs` now routes all three actions to their handlers (`pipeline` → `_create_pipeline_demo_crs`, `inference` → `_create_inference_demo_crs`, `inference-multicluster` → `_create_inference_multicluster_demo_crs`) with the cluster/apply calls stubbed.
- Confirmed an unknown action is still rejected up front, before `_assert_sandbox_cluster_running()` and before the project CR is applied.
- `ruff check` and `ruff format --check` clean on the file.

**Potential risks**

Effectively none. One-line change that only widens an allowlist to a value the CLI already registers and already knows how to dispatch. It cannot affect the `pipeline` or `inference` paths, and unknown actions are still rejected.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A — restores intended behavior of an existing sandbox command.

**Documentation Changes**

N/A — the command and its docs already exist; only the code path was broken.