### PR TITLE
refactor(python): register sandbox demo actions in one table

### DIFF
--- a/python/michelangelo/cli/sandbox/sandbox.py
+++ b/python/michelangelo/cli/sandbox/sandbox.py
@@ -9,9 +9,10 @@ import sys
 import tempfile
 import time
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import yaml
 
@@ -151,6 +152,36 @@ _inference_compute_cluster_names = [
 ]
 
 
+class _DemoAction(NamedTuple):
+    """One `ma sandbox demo` action: argparse help text and the handler that runs it."""
+
+    help: str
+    handler: Callable[[], None]
+
+
+def _demo_actions() -> dict[str, _DemoAction]:
+    """The demo types `ma sandbox demo` accepts.
+
+    Both the CLI subparsers and the dispatch in `_create_demo_crs` are derived
+    from this, so a new demo needs only one entry here. Resolved lazily because
+    the handlers are defined further down the module.
+    """
+    return {
+        "pipeline": _DemoAction(
+            help="Create pipeline demo resources",
+            handler=_create_pipeline_demo_crs,
+        ),
+        "inference": _DemoAction(
+            help="Create inference server demo resources",
+            handler=_create_inference_demo_crs,
+        ),
+        "inference-multicluster": _DemoAction(
+            help="Create a multi-cluster inference server demo.",
+            handler=_create_inference_multicluster_demo_crs,
+        ),
+    }
+
+
 def init_arguments(p: argparse.ArgumentParser):
     """Initialize command-line arguments for the sandbox CLI."""
     sp = p.add_subparsers(dest="action", required=True)
@@ -258,12 +289,8 @@ def init_arguments(p: argparse.ArgumentParser):
     demo_sp = demo_p.add_subparsers(
         dest="demo_action", required=True, help="Demo type to create"
     )
-    _ = demo_sp.add_parser("pipeline", help="Create pipeline demo resources")
-    _ = demo_sp.add_parser("inference", help="Create inference server demo resources")
-    _ = demo_sp.add_parser(
-        "inference-multicluster",
-        help=("Create a multi-cluster inference server demo."),
-    )
+    for demo_action, spec in _demo_actions().items():
+        _ = demo_sp.add_parser(demo_action, help=spec.help)
 
     snapshot_p = sp.add_parser(
         "snapshot", help="Capture or restore Michelangelo CRD state."
@@ -1233,7 +1260,8 @@ def _assert_sandbox_cluster_running():
 def _create_demo_crs(ns: argparse.Namespace):
     """Create demo Custom Resources (CRs) for the sandbox environment."""
     assert ns
-    if ns.demo_action not in ("pipeline", "inference", "inference-multicluster"):
+    demo_actions = _demo_actions()
+    if ns.demo_action not in demo_actions:
         raise ValueError(f"Unsupported demo action: {ns.demo_action}")
 
     _assert_sandbox_cluster_running()
@@ -1258,14 +1286,7 @@ def _create_demo_crs(ns: argparse.Namespace):
     else:
         _err_exit(f"❌ Project CR not found at {project_yaml_path}, exiting...")
 
-    if ns.demo_action == "pipeline":
-        _create_pipeline_demo_crs()
-    elif ns.demo_action == "inference":
-        _create_inference_demo_crs()
-    elif ns.demo_action == "inference-multicluster":
-        _create_inference_multicluster_demo_crs()
-    else:
-        raise ValueError(f"Unsupported demo action: {ns.demo_action}")
+    demo_actions[ns.demo_action].handler()
 
 
 def _snapshot(ns: argparse.Namespace):

--- a/python/michelangelo/cli/sandbox/sandbox_test.py
+++ b/python/michelangelo/cli/sandbox/sandbox_test.py
@@ -193,3 +193,71 @@ class SnapshotRestoreTest(TestCase):
         ):
             sandbox._snapshot_restore(argparse.Namespace(timestamp="does-not-exist"))
         mock_err.assert_called_once()
+
+
+class DemoActionRegistryTest(TestCase):
+    """Parser registration and dispatch share a single `_demo_actions` table."""
+
+    def test_parser_accepts_every_registered_demo_action(self):
+        """Every key in `_demo_actions` is a valid `ma sandbox demo` subcommand."""
+        parser = argparse.ArgumentParser()
+        sandbox.init_arguments(parser)
+        for action in sandbox._demo_actions():
+            ns = parser.parse_args(["demo", action])
+            self.assertEqual(ns.demo_action, action)
+
+    def test_parser_rejects_unknown_demo_action(self):
+        """Argparse rejects a demo action that is not in the registry."""
+        parser = argparse.ArgumentParser()
+        sandbox.init_arguments(parser)
+        with self.assertRaises(SystemExit):
+            parser.parse_args(["demo", "not-a-real-demo"])
+
+    def test_create_demo_crs_dispatches_registered_actions(self):
+        """Each registered action reaches its handler after the shared project CR."""
+        called = []
+        handlers = {
+            action: (lambda a=action: called.append(a))
+            for action in sandbox._demo_actions()
+        }
+        project = {
+            "apiVersion": "michelangelo.api/v2",
+            "kind": "Project",
+            "metadata": {"name": "demo", "namespace": "ma-dev-test"},
+        }
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            demo_dir = Path(tmp_dir) / "demo"
+            demo_dir.mkdir()
+            with open(demo_dir / "project.yaml", "w") as f:
+                yaml.safe_dump(project, f)
+
+            with (
+                patch.object(sandbox, "_dir", Path(tmp_dir)),
+                patch.object(sandbox, "_assert_sandbox_cluster_running"),
+                patch.object(sandbox, "_ensure_namespace_exists"),
+                patch.object(sandbox, "_kube_apply"),
+                patch.object(
+                    sandbox,
+                    "_demo_actions",
+                    return_value={
+                        action: sandbox._DemoAction(help=action, handler=handler)
+                        for action, handler in handlers.items()
+                    },
+                ),
+            ):
+                for action in handlers:
+                    sandbox._create_demo_crs(argparse.Namespace(demo_action=action))
+
+        self.assertEqual(called, list(handlers))
+
+    def test_unknown_action_rejected_before_cluster_work(self):
+        """An unknown action fails before any cluster or apply work."""
+        with (
+            patch.object(sandbox, "_assert_sandbox_cluster_running") as mock_running,
+            patch.object(sandbox, "_kube_apply") as mock_apply,
+            self.assertRaises(ValueError) as ctx,
+        ):
+            sandbox._create_demo_crs(argparse.Namespace(demo_action="bogus"))
+        self.assertIn("bogus", str(ctx.exception))
+        mock_running.assert_not_called()
+        mock_apply.assert_not_called()


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Parser registration, the early allowlist in `_create_demo_crs`, and the if/elif dispatch each listed the same demo names independently. They now all come from one `_demo_actions()` table: name → help text + handler. Adding a demo is a single entry.

Rebased onto `main` after #1996 merged. This PR is now a single commit on top of that hotfix.

**Why?**

#1715 drifted one of the three lists and made `ma sandbox demo inference-multicluster` unreachable while leaving the subparser and the dispatch branch intact. A single table is the only way that class of regression stays gone.

**How did you test it?**

Unit:
- `poetry check`
- `ruff check` / `ruff format --check` clean
- `poetry run pytest michelangelo/cli/sandbox/sandbox_test.py` — 10 passed

Live, against `k3d-michelangelo-sandbox` (existing 10-day sandbox; kubectl pointed at that context, not a remote cluster):

- `ma sandbox demo --help` lists `pipeline`, `inference`, `inference-multicluster` with the original help strings
- `ma sandbox demo bogus` exits 2 at argparse (`invalid choice`)
- Registry handler identity (no mock of `_demo_actions`): `pipeline` → `_create_pipeline_demo_crs`, `inference` → `_create_inference_demo_crs`, `inference-multicluster` → `_create_inference_multicluster_demo_crs`
- `ma sandbox demo inference-multicluster` — completed successfully. Applied the multi-cluster IS, waited until `INFERENCE_SERVER_STATE_SERVING`, rolled out `model-sync` on sandbox + `inference-cluster-1`
- `ma sandbox demo inference` — completed successfully. `inference-server-example` stayed `INFERENCE_SERVER_STATE_SERVING`
- `ma sandbox demo pipeline` — completed successfully. Created `training-pipeline`, `eval-pipeline`, `training-pipeline-with-trigger` and two PipelineRuns in `ma-dev-test`

Post-run `kubectl` on the sandbox:
- `inference-server-example` and `inference-server-multicluster` both `INFERENCE_SERVER_STATE_SERVING`
- `model.michelangelo.api/bert-cola-37` present
- pipelines/pipelineruns present in `ma-dev-test`

**Potential risks**

Low. Same three actions, same handlers, same help text. The registry is resolved lazily so handler lookup happens after the module has finished defining them.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A