### PR TITLE
feat(model): validate description length on create/update

### DIFF
--- a/go/components/model/apihook/BUILD.bazel
+++ b/go/components/model/apihook/BUILD.bazel
@@ -21,7 +21,6 @@ go_test(
     srcs = ["apihook_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//go/api:go_default_library",
         "//go/api/apimocks:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",

--- a/go/components/model/apihook/BUILD.bazel
+++ b/go/components/model/apihook/BUILD.bazel
@@ -10,6 +10,8 @@ go_library(
         "//go/api/utils:go_default_library",
         "//proto/api/v2:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )
@@ -19,6 +21,7 @@ go_test(
     srcs = ["apihook_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/apimocks:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
@@ -27,6 +30,8 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "@org_uber_go_zap//:go_default_library",
     ],
 )

--- a/go/components/model/apihook/apihook.go
+++ b/go/components/model/apihook/apihook.go
@@ -3,11 +3,9 @@
 // go/components/pipelinerun/apihook and go/components/triggerrun/apihook for
 // the sibling packages this one follows the shape of.
 //
-// This hook implements ONLY api.EnvironmentLabel defaulting/inheritance. It
-// deliberately does not implement
-// description-length validation, pipeline-type label copy, owner/LDAP
-// validation, or revision/pipeline-name label copy — those have no obvious
-// OSS-generic equivalent and are out of scope here.
+// This hook implements api.EnvironmentLabel defaulting/inheritance and
+// description-length validation. It does not implement pipeline-type label
+// copy, owner/LDAP validation, or revision/pipeline-name label copy.
 //
 // BeforeUpdate re-derives the label from Spec.SourcePipelineRun on every
 // update, the same as BeforeCreate: the source PipelineRun's label is the
@@ -18,8 +16,11 @@ package apihook
 
 import (
 	"context"
+	"unicode/utf8"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
@@ -46,12 +47,29 @@ type apiHook struct {
 	defaultEnv string
 }
 
+const maxDescriptionLength = 768
+
 func (a apiHook) BeforeCreate(ctx context.Context, request *v2.CreateModelRequest) error {
+	if err := validateDescription(request.Model); err != nil {
+		return err
+	}
 	return a.applyEnvironmentLabel(ctx, request.Model)
 }
 
 func (a apiHook) BeforeUpdate(ctx context.Context, request *v2.UpdateModelRequest) error {
+	if err := validateDescription(request.Model); err != nil {
+		return err
+	}
 	return a.applyEnvironmentLabel(ctx, request.Model)
+}
+
+func validateDescription(model *v2.Model) error {
+	if n := utf8.RuneCountInString(model.Spec.GetDescription()); n > maxDescriptionLength {
+		return status.Errorf(codes.InvalidArgument,
+			"model description exceeds maximum length of %d characters (got %d)",
+			maxDescriptionLength, n)
+	}
+	return nil
 }
 
 // applyEnvironmentLabel sets api.EnvironmentLabel to the configured default

--- a/go/components/model/apihook/apihook_test.go
+++ b/go/components/model/apihook/apihook_test.go
@@ -2,11 +2,14 @@ package apihook
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +18,51 @@ import (
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
+
+func TestBeforeCreate_RejectsOverlongDescription(t *testing.T) {
+	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
+	longDesc := strings.Repeat("a", maxDescriptionLength+1)
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			Spec: v2.ModelSpec{Description: longDesc},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "model description exceeds maximum length")
+}
+
+func TestBeforeCreate_AcceptsDescriptionAtMaxLength(t *testing.T) {
+	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
+	exactDesc := strings.Repeat("a", maxDescriptionLength)
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			Spec: v2.ModelSpec{Description: exactDesc},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+}
+
+func TestBeforeUpdate_RejectsOverlongDescription(t *testing.T) {
+	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
+	longDesc := strings.Repeat("a", maxDescriptionLength+1)
+	request := &v2.UpdateModelRequest{
+		Model: &v2.Model{
+			Spec: v2.ModelSpec{Description: longDesc},
+		},
+	}
+
+	err := hook.BeforeUpdate(context.Background(), request)
+
+	assert.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
 
 func TestBeforeCreate_DefaultsEnvironmentLabelWhenAbsent(t *testing.T) {
 	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

The Model API hook now rejects `Model` create and update requests when `Spec.Description` exceeds 768 UTF-8 runes, returning `codes.InvalidArgument`. The validation runs before environment-label processing.

**Why?**

Models need a description-length guard to prevent unbounded text from being stored in Kubernetes labels/annotations or metadata storage. The 768-rune limit matches the field's intended use as a short summary.

**How did you test it?**

- Added three unit tests: reject overlong description on create, reject on update, accept exactly-at-limit description.
- All existing `EnvironmentLabel` tests continue to pass unchanged.
- `gofmt -l .` and `golangci-lint run ./...` clean.

**Potential risks**

Existing Models with descriptions over 768 runes will fail on their next update. This is intentional — the field was always meant to be bounded.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

N/A