### PR TITLE
feat(model): inherit pipeline-type, owner, and pipeline-name/revision from source PipelineRun

### DIFF
--- a/go/api/api.go
+++ b/go/api/api.go
@@ -74,6 +74,19 @@ const (
 	// SourcePipelineManifestTypeLabelName is the Kubernetes label key that identifies
 	// the pipeline manifest type (e.g. PIPELINE_MANIFEST_TYPE_ASL).
 	SourcePipelineManifestTypeLabelName = "pipeline.michelangelo/PipelineManifestType"
+
+	// ModelSourcePipelineName records the name of the Pipeline whose
+	// PipelineRun produced a Model.
+	ModelSourcePipelineName = "model.michelangelo/source-pipeline-name"
+
+	// ModelSourcePipelineRevision records the revision identifier (RevisionId
+	// or GitRef fallback) of the Revision used by the PipelineRun that
+	// produced a Model.
+	ModelSourcePipelineRevision = "model.michelangelo/source-pipeline-revision"
+
+	// DefaultSourcePipelineType is the default value for
+	// SourcePipelineTypeLabelName when no source PipelineRun provides one.
+	DefaultSourcePipelineType = "PIPELINE_TYPE_TRAIN"
 )
 
 // DefaultContextTimeout defines the default timeout for the context

--- a/go/components/model/apihook/BUILD.bazel
+++ b/go/components/model/apihook/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     srcs = ["apihook_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/apimocks:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",

--- a/go/components/model/apihook/apihook.go
+++ b/go/components/model/apihook/apihook.go
@@ -21,10 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// RegisterModelAPIHook registers the API hook that defaults and inherits the
-// environment label on Models at create/update time. defaultEnv is the
-// operator-configured default (empty when unconfigured, in which case
-// api.UnspecifiedEnvironment is used instead).
+// RegisterModelAPIHook registers the API hook that defaults and inherits
+// labels and owner metadata on Models at create/update time. defaultEnv is
+// the operator-configured default environment (empty when unconfigured, in
+// which case api.UnspecifiedEnvironment is used instead).
 func RegisterModelAPIHook(logger *zap.Logger, apiHandler api.Handler, defaultEnv string) {
 	v2.RegisterModelAPIHook(apiHook{
 		logger:     logger,
@@ -49,12 +49,13 @@ func (a apiHook) BeforeUpdate(ctx context.Context, request *v2.UpdateModelReques
 }
 
 // applyFromSourcePipelineRun resolves Spec.SourcePipelineRun once, then
-// applies all inherited labels from the resolved source. When the source
-// is unset, unresolvable, or the Get fails, label defaults are still
-// applied — the resolution is best-effort enrichment and never blocks
-// Model creation.
+// applies all inherited labels and owner metadata from the resolved source.
+// When the source is unset, unresolvable, or the Get fails, label defaults
+// are still applied — the resolution is best-effort enrichment and never
+// blocks Model creation.
 func (a apiHook) applyFromSourcePipelineRun(ctx context.Context, model *v2.Model) error {
 	setIfAbsent(model, api.EnvironmentLabel, a.defaultEnvironment())
+	setIfAbsent(model, api.SourcePipelineTypeLabelName, api.DefaultSourcePipelineType)
 
 	src := a.resolveSourcePipelineRun(ctx, model)
 	if src == nil {
@@ -62,6 +63,10 @@ func (a apiHook) applyFromSourcePipelineRun(ctx context.Context, model *v2.Model
 	}
 
 	a.applyEnvironmentLabel(model, src)
+	a.applySourcePipelineTypeLabel(model, src)
+	a.applyOwnerFromActor(model, src)
+	a.applyPipelineNameLabel(model, src)
+	a.applyPipelineRevisionLabel(ctx, model, src)
 	return nil
 }
 
@@ -93,16 +98,64 @@ func (a apiHook) resolveSourcePipelineRun(ctx context.Context, model *v2.Model) 
 	return src
 }
 
-// applyEnvironmentLabel overrides api.EnvironmentLabel on the Model with
-// the source PipelineRun's value when the source carries the label.
 func (a apiHook) applyEnvironmentLabel(model *v2.Model, src *v2.PipelineRun) {
 	if val, ok := src.ObjectMeta.Labels[api.EnvironmentLabel]; ok {
 		setLabel(model, api.EnvironmentLabel, val)
 	}
 }
 
-// defaultEnvironment returns the configured default, or
-// api.UnspecifiedEnvironment when the operator has configured none.
+func (a apiHook) applySourcePipelineTypeLabel(model *v2.Model, src *v2.PipelineRun) {
+	if val, ok := src.ObjectMeta.Labels[api.SourcePipelineTypeLabelName]; ok {
+		setLabel(model, api.SourcePipelineTypeLabelName, val)
+	}
+}
+
+func (a apiHook) applyOwnerFromActor(model *v2.Model, src *v2.PipelineRun) {
+	actor := src.Spec.GetActor()
+	if actor.GetName() == "" && actor.GetProxyUser() == "" {
+		return
+	}
+	if model.Spec.Owner == nil {
+		model.Spec.Owner = &v2.UserInfo{}
+	}
+	if actor.GetName() != "" {
+		model.Spec.Owner.Name = actor.GetName()
+	}
+	if actor.GetProxyUser() != "" {
+		model.Spec.Owner.ProxyUser = actor.GetProxyUser()
+	}
+}
+
+func (a apiHook) applyPipelineNameLabel(model *v2.Model, src *v2.PipelineRun) {
+	if name := src.Spec.GetPipeline().GetName(); name != "" {
+		setLabel(model, api.ModelSourcePipelineName, name)
+	}
+}
+
+func (a apiHook) applyPipelineRevisionLabel(ctx context.Context, model *v2.Model, src *v2.PipelineRun) {
+	revRef := src.Spec.GetRevision()
+	if revRef.GetName() == "" {
+		return
+	}
+	namespace := revRef.GetNamespace()
+	if namespace == "" {
+		namespace = src.GetNamespace()
+	}
+
+	rev := &v2.Revision{}
+	if err := a.apiHandler.Get(ctx, namespace, revRef.GetName(), &metav1.GetOptions{}, rev); err != nil {
+		a.logger.Warn("applyPipelineRevisionLabel: failed to resolve Revision, skipping label",
+			zap.String("revision", revRef.GetName()), zap.Error(err))
+		return
+	}
+
+	if id := rev.Spec.GetRevisionId(); id != "" {
+		setLabel(model, api.ModelSourcePipelineRevision, id)
+	} else if ref := rev.Spec.GetGitCommit().GetGitRef(); ref != "" {
+		setLabel(model, api.ModelSourcePipelineRevision, ref)
+	}
+}
+
 func (a apiHook) defaultEnvironment() string {
 	if a.defaultEnv == "" {
 		return api.UnspecifiedEnvironment

--- a/go/components/model/apihook/apihook_test.go
+++ b/go/components/model/apihook/apihook_test.go
@@ -11,10 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/api/apimocks"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 )
+
+// ---------------------------------------------------------------------------
+// EnvironmentLabel tests (unchanged from PR #1912)
+// ---------------------------------------------------------------------------
 
 func TestBeforeCreate_DefaultsEnvironmentLabelWhenAbsent(t *testing.T) {
 	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
@@ -121,9 +126,6 @@ func TestBeforeCreate_SourcePipelineRunGetErrors(t *testing.T) {
 
 	err := hook.BeforeCreate(context.Background(), request)
 
-	// Non-not-found Get errors are swallowed (logged as a warning) rather than
-	// propagated: this is a best-effort label-inheritance lookup and must not
-	// block Model creation. See package doc / applyEnvironmentLabel comment.
 	assert.NoError(t, err)
 	assert.Equal(t, "production", request.Model.Labels["michelangelo/environment"])
 }
@@ -184,4 +186,365 @@ func TestBeforeUpdate_MirrorsBeforeCreate(t *testing.T) {
 
 func TestRegisterModelAPIHook(t *testing.T) {
 	RegisterModelAPIHook(zap.NewNop(), nil, "production")
+}
+
+// ---------------------------------------------------------------------------
+// SourcePipelineTypeLabel tests (Behavior #2)
+// ---------------------------------------------------------------------------
+
+func TestBeforeCreate_DefaultsPipelineTypeLabelWhenAbsent(t *testing.T) {
+	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{Model: &v2.Model{}}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, api.DefaultSourcePipelineType, request.Model.Labels[api.SourcePipelineTypeLabelName])
+}
+
+func TestBeforeCreate_InheritsPipelineTypeLabelFromSource(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.ObjectMeta.Labels = map[string]string{
+				api.SourcePipelineTypeLabelName: "PIPELINE_TYPE_EVAL",
+			}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "PIPELINE_TYPE_EVAL", request.Model.Labels[api.SourcePipelineTypeLabelName])
+}
+
+func TestBeforeCreate_PreservesExplicitPipelineTypeLabel(t *testing.T) {
+	hook := apiHook{logger: zap.NewNop(), defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{api.SourcePipelineTypeLabelName: "PIPELINE_TYPE_PREDICTION"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "PIPELINE_TYPE_PREDICTION", request.Model.Labels[api.SourcePipelineTypeLabelName])
+}
+
+func TestBeforeCreate_PipelineTypeLabelKeepsDefaultWhenSourceLacks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.ObjectMeta.Labels = map[string]string{}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, api.DefaultSourcePipelineType, request.Model.Labels[api.SourcePipelineTypeLabelName])
+}
+
+// ---------------------------------------------------------------------------
+// Owner/actor copy tests (Behavior #3)
+// ---------------------------------------------------------------------------
+
+func TestBeforeCreate_CopiesOwnerFromSourceActor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Actor = &v2.UserInfo{Name: "alice", ProxyUser: "bob"}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "alice", request.Model.Spec.GetOwner().GetName())
+	assert.Equal(t, "bob", request.Model.Spec.GetOwner().GetProxyUser())
+}
+
+func TestBeforeCreate_DoesNotOverwriteOwnerWhenActorEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				Owner:             &v2.UserInfo{Name: "existing-owner"},
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "existing-owner", request.Model.Spec.GetOwner().GetName())
+}
+
+func TestBeforeCreate_CopiesPartialActorFields(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Actor = &v2.UserInfo{Name: "alice"}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				Owner:             &v2.UserInfo{ProxyUser: "keep-me"},
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "alice", request.Model.Spec.GetOwner().GetName())
+	assert.Equal(t, "keep-me", request.Model.Spec.GetOwner().GetProxyUser())
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline-name / revision label copy tests (Behavior #4)
+// ---------------------------------------------------------------------------
+
+func TestBeforeCreate_CopiesPipelineNameLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Pipeline = &apipb.ResourceIdentifier{Name: "my-pipeline"}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "my-pipeline", request.Model.Labels[api.ModelSourcePipelineName])
+}
+
+func TestBeforeCreate_NoPipelineNameLabelWhenPipelineAbsent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	_, exists := request.Model.Labels[api.ModelSourcePipelineName]
+	assert.False(t, exists)
+}
+
+func TestBeforeCreate_CopiesRevisionIdLabel(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.AssignableToTypeOf(&v2.PipelineRun{})).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Revision = &apipb.ResourceIdentifier{Name: "rev-1", Namespace: "ns"}
+			return nil
+		})
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "rev-1", gomock.Any(), gomock.AssignableToTypeOf(&v2.Revision{})).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			rev := obj.(*v2.Revision)
+			rev.Spec.RevisionId = "abc123"
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", request.Model.Labels[api.ModelSourcePipelineRevision])
+}
+
+func TestBeforeCreate_FallsBackToGitRefWhenRevisionIdEmpty(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.AssignableToTypeOf(&v2.PipelineRun{})).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Revision = &apipb.ResourceIdentifier{Name: "rev-2", Namespace: "ns"}
+			return nil
+		})
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "rev-2", gomock.Any(), gomock.AssignableToTypeOf(&v2.Revision{})).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			rev := obj.(*v2.Revision)
+			rev.Spec.GitCommit = &v2.CommitInfo{GitRef: "refs/heads/main"}
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "refs/heads/main", request.Model.Labels[api.ModelSourcePipelineRevision])
+}
+
+func TestBeforeCreate_RevisionGetFailureIsNonFatal(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.AssignableToTypeOf(&v2.PipelineRun{})).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			run := obj.(*v2.PipelineRun)
+			run.Spec.Revision = &apipb.ResourceIdentifier{Name: "rev-gone", Namespace: "ns"}
+			return nil
+		})
+
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "rev-gone", gomock.Any(), gomock.AssignableToTypeOf(&v2.Revision{})).
+		Return(assert.AnError)
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	_, exists := request.Model.Labels[api.ModelSourcePipelineRevision]
+	assert.False(t, exists)
+}
+
+func TestBeforeCreate_NoRevisionLabelWhenRevisionAbsent(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockHandler := apimocks.NewMockHandler(ctrl)
+	mockHandler.EXPECT().
+		Get(gomock.Any(), "ns", "run", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _ *metav1.GetOptions, obj interface{}) error {
+			return nil
+		})
+
+	hook := apiHook{logger: zap.NewNop(), apiHandler: mockHandler, defaultEnv: "staging"}
+	request := &v2.CreateModelRequest{
+		Model: &v2.Model{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns"},
+			Spec: v2.ModelSpec{
+				SourcePipelineRun: &apipb.ResourceIdentifier{Namespace: "ns", Name: "run"},
+			},
+		},
+	}
+
+	err := hook.BeforeCreate(context.Background(), request)
+
+	assert.NoError(t, err)
+	_, exists := request.Model.Labels[api.ModelSourcePipelineRevision]
+	assert.False(t, exists)
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added three new behaviors to the Model API hook, building on the refactored `resolveSourcePipelineRun` shape from #2003:

1. **Pipeline-type label default/override**: defaults `SourcePipelineTypeLabelName` to `PIPELINE_TYPE_TRAIN`; overrides from the source PipelineRun's own label when present.
2. **Owner/actor copy**: copies `Owner.Name`/`ProxyUser` from `PipelineRun.Spec.Actor` when set.
3. **Pipeline-name/revision label copy**: stamps `ModelSourcePipelineName` from `PipelineRun.Spec.Pipeline.Name`; resolves the `Revision` via a second `Get` and stamps `ModelSourcePipelineRevision` with `RevisionId` (fallback `GitRef`). Revision `Get` failure is non-fatal (log-and-skip).

New constants in `go/api/api.go`: `ModelSourcePipelineName`, `ModelSourcePipelineRevision`, `DefaultSourcePipelineType`.

**Why?**

These behaviors are needed for feature parity so that Models carry the same provenance metadata (pipeline type, owner identity, source pipeline/revision) that callers expect.

**How did you test it?**

- 13 new unit tests covering all four test-case templates per behavior (default-when-absent, inherit-from-source, preserve-explicit, source-lacks-label) plus revision-specific cases (RevisionId vs GitRef fallback, Get failure non-fatal, revision absent).
- All 9 existing `EnvironmentLabel` tests pass unchanged.
- `gofmt -l .` and `golangci-lint run ./...` clean.

**Potential risks**

Models will now have additional labels stamped on create/update. Existing Models without these labels are unaffected until their next update, at which point the hook will apply defaults.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

N/A