### PR TITLE
fix(trainer): default to SingleDeviceStrategy when world size is 1

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -326,18 +326,12 @@ def _prepare_trainer_for_ray(trainer: pl.Trainer) -> pl.Trainer:
 
 
 def _resolve_single_device() -> torch.device:
-    """Pick the best available single device: TPU > MPS > CUDA > CPU.
+    """Pick the best available single device: MPS > CUDA > CPU.
 
-    Mirrors Lightning's own auto-detection order:
+    Mirrors Lightning's own auto-detection order (minus TPU, which the
+    trainer SDK does not currently support):
     https://github.com/Lightning-AI/pytorch-lightning/blob/411eec98d50368d700c45edd29d9c20b21e7be17/src/lightning/fabric/utilities/device_parser.py#L209-L221
     """
-    try:
-        from pytorch_lightning.accelerators import XLAAccelerator
-
-        if XLAAccelerator.is_available():
-            return torch.device("xla")
-    except ImportError:
-        pass
     if torch.backends.mps.is_available():
         return torch.device("mps")
     if torch.cuda.is_available():
@@ -348,9 +342,9 @@ def _resolve_single_device() -> torch.device:
 class RaySingleDeviceStrategy(SingleDeviceStrategy):
     """Ray glue for single-device training.
 
-    Resolves the best available device (TPU, then MPS on Apple Silicon, then
-    CUDA if Ray assigned one, then CPU) so that Lightning's auto-detected
-    accelerator and the strategy agree on the device.
+    Resolves the best available device (MPS on Apple Silicon, then CUDA if
+    Ray assigned one, then CPU) so that Lightning's auto-detected accelerator
+    and the strategy agree on the device.
     """
 
     def __init__(self, **kwargs: Any):

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -332,7 +332,7 @@ def _resolve_single_device() -> torch.device:
     https://github.com/Lightning-AI/pytorch-lightning/blob/411eec98d50368d700c45edd29d9c20b21e7be17/src/lightning/fabric/utilities/device_parser.py#L209-L221
     """
     try:
-        from lightning.fabric.accelerators.xla import XLAAccelerator
+        from pytorch_lightning.accelerators import XLAAccelerator
 
         if XLAAccelerator.is_available():
             return torch.device("xla")

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -27,7 +27,7 @@ from pytorch_lightning.plugins import (
     LayerSync,
     Precision,
 )
-from pytorch_lightning.strategies import Strategy
+from pytorch_lightning.strategies import SingleDeviceStrategy, Strategy
 from ray.train.lightning import (
     RayDDPStrategy,
     RayDeepSpeedStrategy,
@@ -302,14 +302,17 @@ def _is_deepspeed_strategy(strategy: str | Strategy | None) -> bool:
 
 
 def _prepare_trainer_for_ray(trainer: pl.Trainer) -> pl.Trainer:
-    """Prepare a Lightning Trainer for Ray, tolerating ModelParallelStrategy (FSDP2).
+    """Prepare a Lightning Trainer for Ray, tolerating strategies Ray doesn't know about.
 
     Ray's ``prepare_trainer`` hard-rejects any strategy that is not
-    ``RayDDPStrategy``/``RayFSDPStrategy``/``RayDeepSpeedStrategy``. For FSDP2 we replicate
-    its only meaningful check -- that the cluster environment is ``RayLightningEnvironment`` --
+    ``RayDDPStrategy``/``RayFSDPStrategy``/``RayDeepSpeedStrategy``. For FSDP2
+    (ModelParallelStrategy) and ``RaySingleDeviceStrategy`` we replicate its only
+    meaningful check -- that the cluster environment is ``RayLightningEnvironment`` --
     and return the trainer unchanged; for the supported strategies we defer to Ray.
     """
-    if _is_model_parallel_strategy(trainer.strategy):
+    if _is_model_parallel_strategy(trainer.strategy) or isinstance(
+        trainer.strategy, RaySingleDeviceStrategy
+    ):
         cluster_env = getattr(trainer.strategy, "cluster_environment", None)
         if cluster_env is not None and not isinstance(
             cluster_env, RayLightningEnvironment
@@ -322,11 +325,62 @@ def _prepare_trainer_for_ray(trainer: pl.Trainer) -> pl.Trainer:
     return ray.train.lightning.prepare_trainer(trainer)
 
 
+def _resolve_single_device() -> torch.device:
+    """Pick the best available single device: TPU > MPS > CUDA > CPU.
+
+    Mirrors Lightning's own auto-detection order:
+    https://github.com/Lightning-AI/pytorch-lightning/blob/411eec98d50368d700c45edd29d9c20b21e7be17/src/lightning/fabric/utilities/device_parser.py#L209-L221
+    """
+    try:
+        from lightning.fabric.accelerators.xla import XLAAccelerator
+
+        if XLAAccelerator.is_available():
+            return torch.device("xla")
+    except ImportError:
+        pass
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    if torch.cuda.is_available():
+        return ray.train.torch.get_device()
+    return torch.device("cpu")
+
+
+class RaySingleDeviceStrategy(SingleDeviceStrategy):
+    """Ray glue for single-device training.
+
+    Resolves the best available device (CUDA if Ray assigned one, then MPS on
+    Apple Silicon, then CPU) so that Lightning's auto-detected accelerator and
+    the strategy agree on the device.
+    """
+
+    def __init__(self, **kwargs: Any):
+        device = _resolve_single_device()
+        super().__init__(device=device, **kwargs)
+
+
 def _resolve_strategy(
     strategy: str | Strategy | None = None,
     strategy_kwargs: dict[str, Any] | None = None,
 ) -> Strategy:
-    """Factory to create the correct Ray/Lightning strategy based on strategy name or instance."""
+    """Factory to create the correct Ray/Lightning strategy based on strategy name or instance.
+
+    When ``strategy`` is None the function checks the Ray world size: if there is
+    only one device (world_size == 1) it returns a ``SingleDeviceStrategy``; otherwise
+    it falls back to ``RayDDPStrategy``.
+
+    Args:
+        strategy: One of "ddp", "fsdp", "fsdp2", "deepspeed", "single_device", or
+            an existing Strategy instance.  None auto-selects based on world size.
+        strategy_kwargs: Keyword arguments forwarded to the strategy constructor. Ignored
+            when strategy is already a Strategy instance.
+
+    Returns:
+        A Strategy instance ready to pass to the Lightning Trainer.
+
+    Raises:
+        TypeError: If strategy or strategy_kwargs have an unexpected type.
+        ValueError: If strategy is a string that is not one of the supported values.
+    """
     if strategy is not None and not isinstance(strategy, (str, Strategy)):
         raise TypeError(
             f"strategy must be a str, Strategy instance, or None, got {type(strategy)!r}"
@@ -341,8 +395,15 @@ def _resolve_strategy(
 
     strategy_kwargs = strategy_kwargs or {}
 
-    if strategy is None or strategy.lower() == "ddp":
+    if strategy is None:
+        world_size = ray.train.get_context().get_world_size()
+        if world_size == 1:
+            return RaySingleDeviceStrategy(**strategy_kwargs)
         return RayDDPStrategy(**strategy_kwargs)
+    elif strategy.lower() == "ddp":
+        return RayDDPStrategy(**strategy_kwargs)
+    elif strategy.lower() == "single_device":
+        return RaySingleDeviceStrategy(**strategy_kwargs)
     elif strategy.lower() == "deepspeed":
         return RayDeepSpeedStrategy(**strategy_kwargs)
     elif strategy.lower() == "fsdp":
@@ -360,7 +421,7 @@ def _resolve_strategy(
         return RayModelParallelStrategy(**strategy_kwargs)
     else:
         raise ValueError(
-            f"Unsupported strategy: {strategy!r}; expected 'ddp', 'deepspeed', 'fsdp', 'fsdp2', or None"
+            f"Unsupported strategy: {strategy!r}; expected 'ddp', 'deepspeed', 'fsdp', 'fsdp2', 'single_device', or None"
         )
 
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/_private/util.py
@@ -348,9 +348,9 @@ def _resolve_single_device() -> torch.device:
 class RaySingleDeviceStrategy(SingleDeviceStrategy):
     """Ray glue for single-device training.
 
-    Resolves the best available device (CUDA if Ray assigned one, then MPS on
-    Apple Silicon, then CPU) so that Lightning's auto-detected accelerator and
-    the strategy agree on the device.
+    Resolves the best available device (TPU, then MPS on Apple Silicon, then
+    CUDA if Ray assigned one, then CPU) so that Lightning's auto-detected
+    accelerator and the strategy agree on the device.
     """
 
     def __init__(self, **kwargs: Any):

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -170,21 +170,23 @@ class TestResolveStrategy:
 class TestResolveSingleDevice:
     """Device resolution: TPU > MPS > CUDA > CPU."""
 
+    _XLA = "pytorch_lightning.accelerators.XLAAccelerator.is_available"
+
     def test_cpu_fallback(self):
         """Falls back to CPU when no accelerator is available."""
         with (
+            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=False),
             patch("torch.cuda.is_available", return_value=False),
-            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
         ):
             assert _resolve_single_device() == torch.device("cpu")
 
     def test_mps_preferred_over_cpu(self):
         """MPS is selected when available and CUDA is not."""
         with (
+            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=True),
             patch("torch.cuda.is_available", return_value=False),
-            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
         ):
             assert _resolve_single_device() == torch.device("mps")
 
@@ -192,28 +194,28 @@ class TestResolveSingleDevice:
         """CUDA delegates to ``ray.train.torch.get_device()`` for the GPU index."""
         cuda_device = torch.device("cuda", 3)
         with (
+            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=False),
             patch("torch.cuda.is_available", return_value=True),
             patch("ray.train.torch.get_device", return_value=cuda_device),
-            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
         ):
             assert _resolve_single_device() == cuda_device
 
     def test_mps_preferred_over_cuda(self):
         """MPS takes priority over CUDA (matches Lightning's order)."""
         with (
+            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=True),
             patch("torch.cuda.is_available", return_value=True),
-            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
         ):
             assert _resolve_single_device() == torch.device("mps")
 
     def test_xla_import_failure_is_tolerated(self):
-        """When ``lightning.fabric.accelerators.xla`` cannot be imported, XLA is skipped."""
+        """When ``pytorch_lightning.accelerators.XLAAccelerator`` cannot be imported, XLA is skipped."""
         with (
             patch("torch.backends.mps.is_available", return_value=False),
             patch("torch.cuda.is_available", return_value=False),
-            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+            patch.dict("sys.modules", {"pytorch_lightning.accelerators": None}),
         ):
             assert _resolve_single_device() == torch.device("cpu")
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -67,7 +67,9 @@ class TestResolveStrategy:
         mock_cls.assert_called_once_with()
         assert result is mock_cls.return_value
 
-    @pytest.mark.parametrize("name", ["single_device", "Single_Device", "SINGLE_DEVICE"])
+    @pytest.mark.parametrize(
+        "name", ["single_device", "Single_Device", "SINGLE_DEVICE"]
+    )
     def test_single_device_string_resolves_case_insensitively(self, name):
         """The string ``"single_device"`` routes to ``RaySingleDeviceStrategy``."""
         with patch(f"{_UTIL_MODULE}.RaySingleDeviceStrategy") as mock_cls:
@@ -226,13 +228,17 @@ class TestRaySingleDeviceStrategy:
 
     def test_root_device_from_resolve(self):
         """``root_device`` matches what ``_resolve_single_device`` returns."""
-        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("mps")):
+        with patch(
+            f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("mps")
+        ):
             strategy = RaySingleDeviceStrategy()
         assert strategy.root_device == torch.device("mps")
 
     def test_cpu_device(self):
         """Works with CPU device."""
-        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+        with patch(
+            f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")
+        ):
             strategy = RaySingleDeviceStrategy()
         assert strategy.root_device == torch.device("cpu")
 
@@ -342,7 +348,9 @@ class TestPrepareTrainerForRay:
 
     def test_single_device_strategy_bypasses_ray_prepare(self):
         """``RaySingleDeviceStrategy`` bypasses Ray's strategy whitelist check."""
-        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+        with patch(
+            f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")
+        ):
             strategy = RaySingleDeviceStrategy()
         trainer = MagicMock()
         trainer.strategy = strategy
@@ -353,7 +361,9 @@ class TestPrepareTrainerForRay:
 
     def test_single_device_strategy_with_wrong_cluster_env_raises(self):
         """``RaySingleDeviceStrategy`` with an unexpected cluster environment raises."""
-        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+        with patch(
+            f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")
+        ):
             strategy = RaySingleDeviceStrategy()
         strategy.cluster_environment = object()
         trainer = MagicMock()

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -168,14 +168,11 @@ class TestResolveStrategy:
 
 
 class TestResolveSingleDevice:
-    """Device resolution: TPU > MPS > CUDA > CPU."""
-
-    _XLA = "pytorch_lightning.accelerators.XLAAccelerator.is_available"
+    """Device resolution: MPS > CUDA > CPU."""
 
     def test_cpu_fallback(self):
         """Falls back to CPU when no accelerator is available."""
         with (
-            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=False),
             patch("torch.cuda.is_available", return_value=False),
         ):
@@ -184,7 +181,6 @@ class TestResolveSingleDevice:
     def test_mps_preferred_over_cpu(self):
         """MPS is selected when available and CUDA is not."""
         with (
-            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=True),
             patch("torch.cuda.is_available", return_value=False),
         ):
@@ -194,7 +190,6 @@ class TestResolveSingleDevice:
         """CUDA delegates to ``ray.train.torch.get_device()`` for the GPU index."""
         cuda_device = torch.device("cuda", 3)
         with (
-            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=False),
             patch("torch.cuda.is_available", return_value=True),
             patch("ray.train.torch.get_device", return_value=cuda_device),
@@ -204,20 +199,10 @@ class TestResolveSingleDevice:
     def test_mps_preferred_over_cuda(self):
         """MPS takes priority over CUDA (matches Lightning's order)."""
         with (
-            patch(self._XLA, return_value=False),
             patch("torch.backends.mps.is_available", return_value=True),
             patch("torch.cuda.is_available", return_value=True),
         ):
             assert _resolve_single_device() == torch.device("mps")
-
-    def test_xla_import_failure_is_tolerated(self):
-        """When ``pytorch_lightning.accelerators.XLAAccelerator`` cannot be imported, XLA is skipped."""
-        with (
-            patch("torch.backends.mps.is_available", return_value=False),
-            patch("torch.cuda.is_available", return_value=False),
-            patch.dict("sys.modules", {"pytorch_lightning.accelerators": None}),
-        ):
-            assert _resolve_single_device() == torch.device("cpu")
 
 
 # -----------------------------------------------------------------------------

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/tests/test_resolve_helpers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint
 from pytorch_lightning.loggers import Logger
 from ray.train.lightning import (
@@ -22,6 +23,7 @@ from ray.train.lightning import (
 )
 
 from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
+    RaySingleDeviceStrategy,
     _accepts_run_id,
     _is_deepspeed_strategy,
     _is_model_parallel_strategy,
@@ -29,6 +31,7 @@ from michelangelo.lib.trainer.torch.pytorch_lightning._private.util import (
     _resolve_callbacks,
     _resolve_logger,
     _resolve_plugins,
+    _resolve_single_device,
     _resolve_strategy,
     build_comet_logger,
     build_mlflow_logger,
@@ -45,9 +48,32 @@ _UTIL_MODULE = "michelangelo.lib.trainer.torch.pytorch_lightning._private.util"
 class TestResolveStrategy:
     """Strategy name / instance → Ray-Lightning Strategy resolution."""
 
-    def test_none_defaults_to_ddp(self):
-        """``None`` resolves to :class:`RayDDPStrategy`."""
-        assert isinstance(_resolve_strategy(None), RayDDPStrategy)
+    def test_none_with_world_size_gt1_defaults_to_ddp(self):
+        """``None`` with world_size > 1 resolves to :class:`RayDDPStrategy`."""
+        ctx = MagicMock()
+        ctx.get_world_size.return_value = 2
+        with patch("ray.train.get_context", return_value=ctx):
+            assert isinstance(_resolve_strategy(None), RayDDPStrategy)
+
+    def test_none_with_world_size_1_defaults_to_single_device(self):
+        """``None`` with world_size == 1 resolves to :class:`RaySingleDeviceStrategy`."""
+        ctx = MagicMock()
+        ctx.get_world_size.return_value = 1
+        with (
+            patch("ray.train.get_context", return_value=ctx),
+            patch(f"{_UTIL_MODULE}.RaySingleDeviceStrategy") as mock_cls,
+        ):
+            result = _resolve_strategy(None)
+        mock_cls.assert_called_once_with()
+        assert result is mock_cls.return_value
+
+    @pytest.mark.parametrize("name", ["single_device", "Single_Device", "SINGLE_DEVICE"])
+    def test_single_device_string_resolves_case_insensitively(self, name):
+        """The string ``"single_device"`` routes to ``RaySingleDeviceStrategy``."""
+        with patch(f"{_UTIL_MODULE}.RaySingleDeviceStrategy") as mock_cls:
+            result = _resolve_strategy(name)
+        mock_cls.assert_called_once_with()
+        assert result is mock_cls.return_value
 
     @pytest.mark.parametrize("name", ["ddp", "DDP", "Ddp"])
     def test_ddp_string_resolves_case_insensitively(self, name):
@@ -117,10 +143,98 @@ class TestResolveStrategy:
         ):
             _resolve_strategy("fsdp2")
 
+    def test_none_forwards_strategy_kwargs(self):
+        """``strategy_kwargs`` are forwarded when ``None`` auto-selects."""
+        ctx = MagicMock()
+        ctx.get_world_size.return_value = 1
+        with (
+            patch("ray.train.get_context", return_value=ctx),
+            patch(f"{_UTIL_MODULE}.RaySingleDeviceStrategy") as mock_cls,
+        ):
+            _resolve_strategy(None, strategy_kwargs={"process_group_backend": "gloo"})
+        mock_cls.assert_called_once_with(process_group_backend="gloo")
+
     def test_invalid_strategy_kwargs_type_raises(self):
         """``strategy_kwargs`` must be a dict."""
         with pytest.raises(TypeError, match="strategy_kwargs must be"):
             _resolve_strategy("ddp", strategy_kwargs=["not", "a", "dict"])
+
+
+# -----------------------------------------------------------------------------
+# _resolve_single_device
+# -----------------------------------------------------------------------------
+
+
+class TestResolveSingleDevice:
+    """Device resolution: TPU > MPS > CUDA > CPU."""
+
+    def test_cpu_fallback(self):
+        """Falls back to CPU when no accelerator is available."""
+        with (
+            patch("torch.backends.mps.is_available", return_value=False),
+            patch("torch.cuda.is_available", return_value=False),
+            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+        ):
+            assert _resolve_single_device() == torch.device("cpu")
+
+    def test_mps_preferred_over_cpu(self):
+        """MPS is selected when available and CUDA is not."""
+        with (
+            patch("torch.backends.mps.is_available", return_value=True),
+            patch("torch.cuda.is_available", return_value=False),
+            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+        ):
+            assert _resolve_single_device() == torch.device("mps")
+
+    def test_cuda_uses_ray_device(self):
+        """CUDA delegates to ``ray.train.torch.get_device()`` for the GPU index."""
+        cuda_device = torch.device("cuda", 3)
+        with (
+            patch("torch.backends.mps.is_available", return_value=False),
+            patch("torch.cuda.is_available", return_value=True),
+            patch("ray.train.torch.get_device", return_value=cuda_device),
+            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+        ):
+            assert _resolve_single_device() == cuda_device
+
+    def test_mps_preferred_over_cuda(self):
+        """MPS takes priority over CUDA (matches Lightning's order)."""
+        with (
+            patch("torch.backends.mps.is_available", return_value=True),
+            patch("torch.cuda.is_available", return_value=True),
+            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+        ):
+            assert _resolve_single_device() == torch.device("mps")
+
+    def test_xla_import_failure_is_tolerated(self):
+        """When ``lightning.fabric.accelerators.xla`` cannot be imported, XLA is skipped."""
+        with (
+            patch("torch.backends.mps.is_available", return_value=False),
+            patch("torch.cuda.is_available", return_value=False),
+            patch.dict("sys.modules", {"lightning.fabric.accelerators.xla": None}),
+        ):
+            assert _resolve_single_device() == torch.device("cpu")
+
+
+# -----------------------------------------------------------------------------
+# RaySingleDeviceStrategy
+# -----------------------------------------------------------------------------
+
+
+class TestRaySingleDeviceStrategy:
+    """RaySingleDeviceStrategy delegates device to ``_resolve_single_device``."""
+
+    def test_root_device_from_resolve(self):
+        """``root_device`` matches what ``_resolve_single_device`` returns."""
+        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("mps")):
+            strategy = RaySingleDeviceStrategy()
+        assert strategy.root_device == torch.device("mps")
+
+    def test_cpu_device(self):
+        """Works with CPU device."""
+        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+            strategy = RaySingleDeviceStrategy()
+        assert strategy.root_device == torch.device("cpu")
 
 
 # -----------------------------------------------------------------------------
@@ -189,7 +303,7 @@ class TestIsDeepSpeedStrategy:
 
 
 class TestPrepareTrainerForRay:
-    """Ray trainer preparation, tolerating FSDP2."""
+    """Ray trainer preparation, tolerating FSDP2 and RaySingleDeviceStrategy."""
 
     _IS_MP = f"{_UTIL_MODULE}._is_model_parallel_strategy"
 
@@ -198,6 +312,7 @@ class TestPrepareTrainerForRay:
     def test_non_model_parallel_defers_to_ray(self, mock_prepare, _mock_is_mp):
         """Non-MP strategies delegate to ``ray.train.lightning.prepare_trainer``."""
         trainer = MagicMock()
+        trainer.strategy = RayDDPStrategy()
         result = _prepare_trainer_for_ray(trainer)
         mock_prepare.assert_called_once_with(trainer)
         assert result is mock_prepare.return_value
@@ -224,6 +339,27 @@ class TestPrepareTrainerForRay:
         trainer = MagicMock()
         trainer.strategy.cluster_environment = None
         assert _prepare_trainer_for_ray(trainer) is trainer
+
+    def test_single_device_strategy_bypasses_ray_prepare(self):
+        """``RaySingleDeviceStrategy`` bypasses Ray's strategy whitelist check."""
+        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+            strategy = RaySingleDeviceStrategy()
+        trainer = MagicMock()
+        trainer.strategy = strategy
+        with patch("ray.train.lightning.prepare_trainer") as mock_prepare:
+            result = _prepare_trainer_for_ray(trainer)
+        mock_prepare.assert_not_called()
+        assert result is trainer
+
+    def test_single_device_strategy_with_wrong_cluster_env_raises(self):
+        """``RaySingleDeviceStrategy`` with an unexpected cluster environment raises."""
+        with patch(f"{_UTIL_MODULE}._resolve_single_device", return_value=torch.device("cpu")):
+            strategy = RaySingleDeviceStrategy()
+        strategy.cluster_environment = object()
+        trainer = MagicMock()
+        trainer.strategy = strategy
+        with pytest.raises(RuntimeError, match="RayLightningEnvironment"):
+            _prepare_trainer_for_ray(trainer)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Added `RaySingleDeviceStrategy` and updated `_resolve_strategy()` in the Lightning trainer utilities to auto-select it when `world_size == 1`, instead of unconditionally defaulting to `RayDDPStrategy`.

- New `_resolve_single_device()` helper picks the best available device (TPU > MPS > CUDA > CPU), mirroring [Lightning's own auto-detection order](https://github.com/Lightning-AI/pytorch-lightning/blob/411eec98d50368d700c45edd29d9c20b21e7be17/src/lightning/fabric/utilities/device_parser.py#L209-L221).
- New `RaySingleDeviceStrategy(SingleDeviceStrategy)` class passes the resolved device to Lightning so the strategy and accelerator agree.
- `_resolve_strategy(None)` now checks `ray.train.get_context().get_world_size()`: returns `RaySingleDeviceStrategy` when 1, `RayDDPStrategy` otherwise.
- `_resolve_strategy("single_device")` is supported as an explicit option.
- `_prepare_trainer_for_ray()` bypasses Ray's strategy whitelist check for `RaySingleDeviceStrategy` (same pattern as the existing FSDP2/ModelParallel bypass).

**Why?**

On Apple Silicon Macs, PyTorch Lightning auto-detects the MPS accelerator, but `RayDDPStrategy` (a DDP-family strategy) is incompatible with MPS. This causes a `ValueError: strategies from the DDP family are not supported on the MPS accelerator` when running single-worker training locally (e.g. `python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline`). Since single-worker training doesn't need DDP, using `SingleDeviceStrategy` is the correct choice and also enables MPS acceleration.

**How did you test it?**

- Reproduced the original `ValueError` on Apple Silicon by running `python -m michelangelo_examples.california_housing.pipelines.pytorch_train.pipeline` before the fix.
- Verified the fix runs the full `pytorch_train` pipeline end-to-end locally on Apple Silicon (`feature_prep` → `preprocess` → `train` → `assembler` → `push_step`), with Lightning correctly using MPS (`GPU available: True (mps), used: True`).
- Verified the fix does not affect the sandbox (k3d/Linux) path: `xgb_train` and `pytorch_train` both pass on a k3d sandbox where `world_size > 1` and DDP is used as before.

**Potential risks**

- `_resolve_single_device()` imports `XLAAccelerator` from `lightning.fabric` — wrapped in a `try`/`except ImportError` to handle environments without XLA installed.
- Multi-worker training is unaffected: `_resolve_strategy(None)` only selects `RaySingleDeviceStrategy` when `world_size == 1`; multi-worker runs continue to use `RayDDPStrategy`.
- Ray's `prepare_trainer` is bypassed for `RaySingleDeviceStrategy` (it hard-rejects unknown strategies). The only check it performs that we replicate is validating `RayLightningEnvironment` as the cluster environment plugin.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

Fixed `ValueError` when running Lightning-based training locally on Apple Silicon (MPS). Single-worker training now auto-selects `SingleDeviceStrategy` instead of `RayDDPStrategy`, enabling MPS GPU acceleration on Macs.

**Documentation Changes**

N/A