### PR TITLE
feat(raycluster): terminate cluster missing from remote and mark all terminal states immutable

### DIFF
--- a/go/components/ray/cluster/BUILD.bazel
+++ b/go/components/ray/cluster/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
@@ -39,6 +40,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api/utils:go_default_library",
         "//go/components/jobs/client/clientmocks:go_default_library",
         "//go/components/jobs/cluster:go_default_library",
         "//go/components/jobs/common/types:go_default_library",

--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -115,6 +115,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{RequeueAfter: requeueAfter}, err
 		}
 		logger.Info("processed cluster termination")
+
+		// Once termination has fully converged (kill/cleanup finished, or there was
+		// nothing to clean up), freeze the object so the ingester archives it and
+		// reconciliation stops for good. No-op if cleanup is still in progress; a later
+		// reconcile will pick this back up once it does.
+		if err := r.markImmutableIfTerminal(ctx, &rayCluster); err != nil {
+			logger.Error(err, "failed to mark cluster immutable after termination")
+			return ctrl.Result{RequeueAfter: requeueAfter}, err
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -568,18 +577,64 @@ func (r *Reconciler) getClusterStatus(ctx context.Context, log logr.Logger, assi
 	return clusterStatus, nil
 }
 
+// isClusterFullyTerminal reports whether cluster has fully converged to a terminal
+// outcome: Succeeded is decided (TRUE or FALSE) and any kill/cleanup processing it
+// triggers has completed (Killing back to FALSE with Killed TRUE).
+//
+// cleanupCluster and markClusterFailedImmutable are the only two places that produce
+// this combination, and both set Killing=FALSE/Killed=TRUE atomically alongside their
+// last piece of cleanup work (or, for markClusterFailedImmutable, with no cleanup needed
+// at all since the remote resource is already confirmed gone). So checking it on a
+// freshly-fetched object is race-free: there is no window where it reads true before
+// cleanup has actually finished.
+func isClusterFullyTerminal(cluster *v2pb.RayCluster) bool {
+	succeeded := jobsutils.GetCondition(&cluster.Status.StatusConditions, SucceededCondition, cluster.Generation)
+	if succeeded.Status == apipb.CONDITION_STATUS_UNKNOWN {
+		return false
+	}
+	killing := jobsutils.GetCondition(&cluster.Status.StatusConditions, KillingCondition, cluster.Generation)
+	killed := jobsutils.GetCondition(&cluster.Status.StatusConditions, KilledCondition, cluster.Generation)
+	return killing.Status == apipb.CONDITION_STATUS_FALSE && killed.Status == apipb.CONDITION_STATUS_TRUE
+}
+
+// markImmutableIfTerminal freezes cluster once it has fully converged to a terminal
+// outcome (see isClusterFullyTerminal), so the ingester moves it to metadata storage and
+// deletes it from K8s/ETCD; after that the controller's Get returns NotFound and
+// reconciliation stops for good. It is a no-op if the object is already immutable, or
+// has not yet reached that point (e.g. Killing is still TRUE while cleanup is in flight)
+// — a later reconcile will call this again once it has.
+//
+// It re-fetches the latest object first, since a status update may have just preceded
+// this call and annotations live on the object metadata, not the status subresource; the
+// re-fetch also avoids a resourceVersion conflict with that preceding update, and the
+// whole operation retries on conflict for the same reason.
+func (r *Reconciler) markImmutableIfTerminal(ctx context.Context, cluster *v2pb.RayCluster) error {
+	if err := retry.OnError(retry.DefaultRetry, jobsutils.IsRetriableError, func() error {
+		latest := &v2pb.RayCluster{}
+		if err := r.Get(ctx, cluster.Namespace, cluster.Name, &metav1.GetOptions{}, latest); err != nil {
+			return err
+		}
+		if utils.IsImmutable(latest) || !isClusterFullyTerminal(latest) {
+			return nil
+		}
+		utils.MarkImmutable(latest)
+		return r.Update(ctx, latest, &metav1.UpdateOptions{})
+	}); err != nil {
+		return fmt.Errorf("failed to mark cluster immutable: %w", err)
+	}
+	return nil
+}
+
 // markClusterFailedImmutable records a terminal failure for a RayCluster whose backing
-// resource has disappeared from the remote compute cluster and freezes the object so it
-// stops being reconciled.
+// resource has disappeared from the remote compute cluster, so it stops being monitored.
 //
-// It first persists a fully-terminal status (State=FAILED, Succeeded=FALSE, Killing=FALSE,
-// Killed=TRUE). Setting the complete terminal condition set means a reconcile that races
-// the ingester's ETCD cleanup short-circuits processClusterTermination into a no-op rather
-// than issuing a pointless DeleteJobCluster against an already-gone remote cluster.
-//
-// It then sets the immutable annotation. The ingester moves the object to metadata storage
-// and deletes it from K8s/ETCD, after which the controller's Get returns NotFound and
-// reconciliation stops permanently.
+// It persists the complete terminal condition set in one write (State=FAILED,
+// Succeeded=FALSE, Killing=FALSE, Killed=TRUE) rather than just setting Succeeded=FALSE
+// and letting processClusterTermination converge over further reconciles: the remote
+// resource is already confirmed gone, so there is nothing to clean up, and setting
+// Killing=FALSE directly means cleanupCluster will never issue a pointless
+// DeleteJobCluster against it. That same condition set is what markImmutableIfTerminal
+// looks for, so it freezes the object immediately after.
 func (r *Reconciler) markClusterFailedImmutable(
 	ctx context.Context,
 	cluster *v2pb.RayCluster,
@@ -617,24 +672,7 @@ func (r *Reconciler) markClusterFailedImmutable(
 		return fmt.Errorf("failed to persist terminal status: %w", err)
 	}
 
-	// Mark the object immutable (metadata). This is a separate Update because annotations
-	// live on the object metadata, not the status subresource. Re-fetch the latest object
-	// to avoid a resourceVersion conflict with the status update above.
-	if err := retry.OnError(retry.DefaultRetry, jobsutils.IsRetriableError, func() error {
-		latest := &v2pb.RayCluster{}
-		if err := r.Get(ctx, cluster.Namespace, cluster.Name, &metav1.GetOptions{}, latest); err != nil {
-			return err
-		}
-		if utils.IsImmutable(latest) {
-			return nil
-		}
-		utils.MarkImmutable(latest)
-		return r.Update(ctx, latest, &metav1.UpdateOptions{})
-	}); err != nil {
-		return fmt.Errorf("failed to mark cluster immutable: %w", err)
-	}
-
-	return nil
+	return r.markImmutableIfTerminal(ctx, cluster)
 }
 
 // applyRayClusterStatus updates the RayCluster status and conditions based on the cluster state from KubeRay.

--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -196,8 +197,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	clusterStatus, err := r.getClusterStatus(ctx, logger, assignedCluster, &rayCluster)
 	if err != nil {
 		if utils.IsNotFoundError(err) {
-			logger.Info("cluster not found on remote cluster, requeue")
-			return ctrl.Result{RequeueAfter: requeueAfter}, nil
+			// The RayCluster no longer exists on the remote compute cluster. This is a
+			// terminal, non-recoverable condition: there is nothing left to monitor or
+			// clean up. Mark it failed + immutable so the ingester freezes the object and
+			// we stop reconciling, instead of requeuing forever.
+			logger.Info("cluster not found on remote compute cluster, marking as failed and immutable")
+			if err := r.markClusterFailedImmutable(ctx, &rayCluster,
+				"ClusterNotFoundOnRemote",
+				"RayCluster no longer exists on the remote compute cluster",
+			); err != nil {
+				logger.Error(err, "failed to mark cluster as failed and immutable")
+				return ctrl.Result{RequeueAfter: requeueAfter}, err
+			}
+			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "failed to get cluster status")
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
@@ -554,6 +566,75 @@ func (r *Reconciler) getClusterStatus(ctx context.Context, log logr.Logger, assi
 		"state", clusterStatus.Ray.State)
 
 	return clusterStatus, nil
+}
+
+// markClusterFailedImmutable records a terminal failure for a RayCluster whose backing
+// resource has disappeared from the remote compute cluster and freezes the object so it
+// stops being reconciled.
+//
+// It first persists a fully-terminal status (State=FAILED, Succeeded=FALSE, Killing=FALSE,
+// Killed=TRUE). Setting the complete terminal condition set means a reconcile that races
+// the ingester's ETCD cleanup short-circuits processClusterTermination into a no-op rather
+// than issuing a pointless DeleteJobCluster against an already-gone remote cluster.
+//
+// It then sets the immutable annotation. The ingester moves the object to metadata storage
+// and deletes it from K8s/ETCD, after which the controller's Get returns NotFound and
+// reconciliation stops permanently.
+func (r *Reconciler) markClusterFailedImmutable(
+	ctx context.Context,
+	cluster *v2pb.RayCluster,
+	reason string,
+	message string,
+) error {
+	// Persist the terminal status via the status subresource.
+	if err := jobsutils.UpdateStatusWithRetries(
+		ctx, r, cluster,
+		func(obj client.Object) {
+			c := obj.(*v2pb.RayCluster)
+			c.Status.State = v2pb.RAY_CLUSTER_STATE_FAILED
+
+			succeededCond := jobsutils.GetCondition(&c.Status.StatusConditions, SucceededCondition, c.Generation)
+			jobsutils.UpdateCondition(succeededCond, jobsutils.ConditionUpdateParams{
+				Status:     apipb.CONDITION_STATUS_FALSE,
+				Generation: c.Generation,
+				Reason:     reason,
+				Message:    message,
+			})
+			killingCond := jobsutils.GetCondition(&c.Status.StatusConditions, KillingCondition, c.Generation)
+			jobsutils.UpdateCondition(killingCond, jobsutils.ConditionUpdateParams{
+				Status:     apipb.CONDITION_STATUS_FALSE,
+				Generation: c.Generation,
+			})
+			killedCond := jobsutils.GetCondition(&c.Status.StatusConditions, KilledCondition, c.Generation)
+			jobsutils.UpdateCondition(killedCond, jobsutils.ConditionUpdateParams{
+				Status:     apipb.CONDITION_STATUS_TRUE,
+				Generation: c.Generation,
+				Reason:     reason,
+			})
+		},
+		&metav1.UpdateOptions{FieldManager: "markClusterFailedImmutable"},
+	); err != nil {
+		return fmt.Errorf("failed to persist terminal status: %w", err)
+	}
+
+	// Mark the object immutable (metadata). This is a separate Update because annotations
+	// live on the object metadata, not the status subresource. Re-fetch the latest object
+	// to avoid a resourceVersion conflict with the status update above.
+	if err := retry.OnError(retry.DefaultRetry, jobsutils.IsRetriableError, func() error {
+		latest := &v2pb.RayCluster{}
+		if err := r.Get(ctx, cluster.Namespace, cluster.Name, &metav1.GetOptions{}, latest); err != nil {
+			return err
+		}
+		if utils.IsImmutable(latest) {
+			return nil
+		}
+		utils.MarkImmutable(latest)
+		return r.Update(ctx, latest, &metav1.UpdateOptions{})
+	}); err != nil {
+		return fmt.Errorf("failed to mark cluster immutable: %w", err)
+	}
+
+	return nil
 }
 
 // applyRayClusterStatus updates the RayCluster status and conditions based on the cluster state from KubeRay.

--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -115,16 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{RequeueAfter: requeueAfter}, err
 		}
 		logger.Info("processed cluster termination")
-
-		// Once termination has fully converged (kill/cleanup finished, or there was
-		// nothing to clean up), freeze the object so the ingester archives it and
-		// reconciliation stops for good. No-op if cleanup is still in progress; a later
-		// reconcile will pick this back up once it does.
-		if err := r.markImmutableIfTerminal(ctx, &rayCluster); err != nil {
-			logger.Error(err, "failed to mark cluster immutable after termination")
-			return ctrl.Result{RequeueAfter: requeueAfter}, err
-		}
-		return ctrl.Result{}, nil
+		return r.finalizeIfTerminal(ctx, &rayCluster, logger)
 	}
 
 	// Enqueue if not scheduled
@@ -208,17 +199,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if utils.IsNotFoundError(err) {
 			// The RayCluster no longer exists on the remote compute cluster. This is a
 			// terminal, non-recoverable condition: there is nothing left to monitor or
-			// clean up. Mark it failed + immutable so the ingester freezes the object and
-			// we stop reconciling, instead of requeuing forever.
-			logger.Info("cluster not found on remote compute cluster, marking as failed and immutable")
-			if err := r.markClusterFailedImmutable(ctx, &rayCluster,
+			// clean up. Mark it failed so we stop reconciling instead of requeuing forever.
+			logger.Info("cluster not found on remote compute cluster, marking as failed")
+			if err := r.markClusterFailed(ctx, &rayCluster,
 				"ClusterNotFoundOnRemote",
 				"RayCluster no longer exists on the remote compute cluster",
 			); err != nil {
-				logger.Error(err, "failed to mark cluster as failed and immutable")
+				logger.Error(err, "failed to mark cluster as failed")
 				return ctrl.Result{RequeueAfter: requeueAfter}, err
 			}
-			return ctrl.Result{}, nil
+			return r.finalizeIfTerminal(ctx, &rayCluster, logger)
 		}
 		logger.Error(err, "failed to get cluster status")
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
@@ -581,12 +571,12 @@ func (r *Reconciler) getClusterStatus(ctx context.Context, log logr.Logger, assi
 // outcome: Succeeded is decided (TRUE or FALSE) and any kill/cleanup processing it
 // triggers has completed (Killing back to FALSE with Killed TRUE).
 //
-// cleanupCluster and markClusterFailedImmutable are the only two places that produce
-// this combination, and both set Killing=FALSE/Killed=TRUE atomically alongside their
-// last piece of cleanup work (or, for markClusterFailedImmutable, with no cleanup needed
-// at all since the remote resource is already confirmed gone). So checking it on a
-// freshly-fetched object is race-free: there is no window where it reads true before
-// cleanup has actually finished.
+// cleanupCluster and markClusterFailed are the only two places that produce this
+// combination, and both set Killing=FALSE/Killed=TRUE atomically alongside their last
+// piece of cleanup work (or, for markClusterFailed, with no cleanup needed at all since
+// the remote resource is already confirmed gone). So checking it on a freshly-fetched
+// object is race-free: there is no window where it reads true before cleanup has
+// actually finished.
 func isClusterFullyTerminal(cluster *v2pb.RayCluster) bool {
 	succeeded := jobsutils.GetCondition(&cluster.Status.StatusConditions, SucceededCondition, cluster.Generation)
 	if succeeded.Status == apipb.CONDITION_STATUS_UNKNOWN {
@@ -595,6 +585,19 @@ func isClusterFullyTerminal(cluster *v2pb.RayCluster) bool {
 	killing := jobsutils.GetCondition(&cluster.Status.StatusConditions, KillingCondition, cluster.Generation)
 	killed := jobsutils.GetCondition(&cluster.Status.StatusConditions, KilledCondition, cluster.Generation)
 	return killing.Status == apipb.CONDITION_STATUS_FALSE && killed.Status == apipb.CONDITION_STATUS_TRUE
+}
+
+// finalizeIfTerminal is the single call site for freezing a RayCluster. Every path that
+// can drive a cluster to a fully terminal outcome — the normal kill/cleanup convergence
+// in Reconcile's termination branch, and markClusterFailed's NotFound-on-remote write —
+// calls this right after its own status write completes, instead of each calling
+// markImmutableIfTerminal separately.
+func (r *Reconciler) finalizeIfTerminal(ctx context.Context, cluster *v2pb.RayCluster, log logr.Logger) (ctrl.Result, error) {
+	if err := r.markImmutableIfTerminal(ctx, cluster); err != nil {
+		log.Error(err, "failed to mark cluster immutable after termination")
+		return ctrl.Result{RequeueAfter: requeueAfter}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 // markImmutableIfTerminal freezes cluster once it has fully converged to a terminal
@@ -625,17 +628,18 @@ func (r *Reconciler) markImmutableIfTerminal(ctx context.Context, cluster *v2pb.
 	return nil
 }
 
-// markClusterFailedImmutable records a terminal failure for a RayCluster whose backing
-// resource has disappeared from the remote compute cluster, so it stops being monitored.
+// markClusterFailed records a terminal failure for a RayCluster whose backing resource
+// has disappeared from the remote compute cluster, so it stops being monitored.
 //
 // It persists the complete terminal condition set in one write (State=FAILED,
 // Succeeded=FALSE, Killing=FALSE, Killed=TRUE) rather than just setting Succeeded=FALSE
 // and letting processClusterTermination converge over further reconciles: the remote
 // resource is already confirmed gone, so there is nothing to clean up, and setting
 // Killing=FALSE directly means cleanupCluster will never issue a pointless
-// DeleteJobCluster against it. That same condition set is what markImmutableIfTerminal
-// looks for, so it freezes the object immediately after.
-func (r *Reconciler) markClusterFailedImmutable(
+// DeleteJobCluster against it. That same condition set is what isClusterFullyTerminal
+// looks for; the caller is responsible for calling finalizeIfTerminal afterwards to act
+// on it.
+func (r *Reconciler) markClusterFailed(
 	ctx context.Context,
 	cluster *v2pb.RayCluster,
 	reason string,
@@ -667,12 +671,12 @@ func (r *Reconciler) markClusterFailedImmutable(
 				Reason:     reason,
 			})
 		},
-		&metav1.UpdateOptions{FieldManager: "markClusterFailedImmutable"},
+		&metav1.UpdateOptions{FieldManager: "markClusterFailed"},
 	); err != nil {
 		return fmt.Errorf("failed to persist terminal status: %w", err)
 	}
 
-	return r.markImmutableIfTerminal(ctx, cluster)
+	return nil
 }
 
 // applyRayClusterStatus updates the RayCluster status and conditions based on the cluster state from KubeRay.

--- a/go/components/ray/cluster/controller_test.go
+++ b/go/components/ray/cluster/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client/clientmocks"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
 	matypes "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/types"
@@ -1276,6 +1277,79 @@ func TestReconcilerReconcile(t *testing.T) {
 							"SucceededCondition should stay UNKNOWN when no terminal errors")
 					}
 				}
+			},
+		},
+		{
+			name: "Cluster missing on remote compute cluster is marked failed and immutable",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayClusterName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: createRayClusterSpec(),
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_PROVISIONING,
+						StatusConditions: []*apipb.Condition{
+							{
+								Type:   EnqueuedCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+							{
+								Type:   ScheduledCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+							{
+								Type:   LaunchedCondition,
+								Status: apipb.CONDITION_STATUS_TRUE,
+							},
+						},
+						Assignment: &v2pb.AssignmentInfo{
+							Cluster: assignedCluster,
+						},
+					},
+				}
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks: func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {
+				mcc.addCluster(assignedCluster, &v2pb.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: assignedCluster,
+					},
+				})
+				// The RayCluster has vanished from the remote compute cluster.
+				mfc.EXPECT().GetJobClusterStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+					nil, apiErrors.NewNotFound(
+						schema.GroupResource{Group: "ray.io", Resource: "rayclusters"}, rayClusterName))
+			},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_FAILED,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				// Terminal condition: the controller must not requeue.
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				var succeededCond, killedCond *apipb.Condition
+				for _, cond := range cluster.Status.StatusConditions {
+					switch cond.Type {
+					case SucceededCondition:
+						succeededCond = cond
+					case KilledCondition:
+						killedCond = cond
+					}
+				}
+				require.NotNil(t, succeededCond, "SucceededCondition should exist")
+				assert.Equal(t, apipb.CONDITION_STATUS_FALSE, succeededCond.Status,
+					"SucceededCondition should be FALSE for a failed cluster")
+				require.NotNil(t, killedCond, "KilledCondition should exist")
+				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status,
+					"KilledCondition should be TRUE for a terminal cluster")
+				assert.True(t, utils.IsImmutable(cluster),
+					"cluster should be marked immutable so reconciliation stops")
 			},
 		},
 	}

--- a/go/components/ray/cluster/controller_test.go
+++ b/go/components/ray/cluster/controller_test.go
@@ -440,6 +440,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, succeededCond, "SucceededCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_FALSE, succeededCond.Status)
+				assert.False(t, utils.IsImmutable(cluster),
+					"cluster should not be immutable yet - cleanup has not run")
 			},
 		},
 		{
@@ -559,6 +561,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, succeededCond, "SucceededCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_FALSE, succeededCond.Status)
+				assert.False(t, utils.IsImmutable(cluster),
+					"cluster should not be immutable yet - this is a transient state on the way to termination")
 			},
 		},
 		{
@@ -677,6 +681,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, succeededCond, "SucceededCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, succeededCond.Status)
+				assert.False(t, utils.IsImmutable(cluster),
+					"cluster should not be immutable yet - kill/cleanup has not converged")
 			},
 		},
 		{
@@ -722,6 +728,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, succeededCond, "SucceededCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_FALSE, succeededCond.Status)
+				assert.False(t, utils.IsImmutable(cluster),
+					"cluster should not be immutable yet - kill/cleanup has not converged")
 			},
 		},
 		{
@@ -776,6 +784,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, killedCond, "KilledCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
+				assert.True(t, utils.IsImmutable(cluster),
+					"cluster should be marked immutable once fully terminated")
 			},
 		},
 		{
@@ -843,6 +853,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, killedCond, "KilledCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
+				assert.True(t, utils.IsImmutable(cluster),
+					"cluster should be marked immutable once fully terminated")
 			},
 		},
 		{
@@ -919,6 +931,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
 				assert.NotNil(t, killingCond, "KillingCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_FALSE, killingCond.Status)
+				assert.True(t, utils.IsImmutable(cluster),
+					"cluster should be marked immutable once fully terminated")
 			},
 		},
 		{
@@ -992,6 +1006,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, killedCond, "KilledCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
+				assert.True(t, utils.IsImmutable(cluster),
+					"cluster should be marked immutable once fully terminated")
 			},
 		},
 		{
@@ -1069,6 +1085,8 @@ func TestReconcilerReconcile(t *testing.T) {
 				assert.Equal(t, "CrashLoopBackOff", succeededCond.Reason)
 				assert.Len(t, cluster.Status.PodErrors, 1)
 				assert.Equal(t, "CrashLoopBackOff", cluster.Status.PodErrors[0].Reason)
+				assert.False(t, utils.IsImmutable(cluster),
+					"cluster should not be immutable yet - this is a transient state on the way to termination")
 			},
 		},
 		{
@@ -1402,4 +1420,71 @@ func TestReconcilerReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReconcilerReconcile_KillConvergesToImmutable exercises a normal (non-NotFound)
+// termination across multiple reconciles: the first reconcile sets Succeeded and Killing
+// but cleanup has not run yet, so the object must stay mutable; only once cleanup
+// converges on Killing=FALSE/Killed=TRUE on the following reconcile should the object be
+// frozen. This is the "mark immutable for all terminal states" path, as opposed to the
+// single-shot NotFound-on-remote path covered by "Cluster missing on remote compute
+// cluster is marked failed and immutable" above.
+func TestReconcilerReconcile_KillConvergesToImmutable(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	kubescheme.AddToScheme(scheme)
+	v2pb.AddToScheme(scheme)
+
+	cluster := &v2pb.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       rayClusterName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+		Spec: v2pb.RayClusterSpec{
+			RayVersion: "2.3.1",
+			Head:       &v2pb.RayHeadSpec{},
+			Termination: &v2pb.TerminationSpec{
+				Type:   v2pb.TERMINATION_TYPE_SUCCEEDED,
+				Reason: "completed",
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster).WithStatusSubresource(cluster).Build()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockFedClient := clientmocks.NewMockFederatedClient(mockCtrl)
+
+	r := &Reconciler{
+		Handler:         &mockAPIHandler{Client: fakeClient},
+		federatedClient: mockFedClient,
+		clusterCache:    newMockClusterCache(),
+		schedulerQueue:  &mockSchedulerQueue{},
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: rayClusterName, Namespace: testNamespace}}
+
+	// First reconcile: Succeeded and Killing get set, but the cluster was never
+	// scheduled/launched so cleanup only sees the change on the next pass.
+	_, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var afterFirst v2pb.RayCluster
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &afterFirst))
+	assert.NotEqual(t, v2pb.RAY_CLUSTER_STATE_TERMINATED, afterFirst.Status.State)
+	assert.False(t, utils.IsImmutable(&afterFirst),
+		"cluster should not be immutable yet - cleanup has not converged")
+
+	// Second reconcile: cleanup now observes Killing=TRUE, completes, and the object
+	// should be frozen immediately after.
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var afterSecond v2pb.RayCluster
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, &afterSecond))
+	assert.Equal(t, v2pb.RAY_CLUSTER_STATE_TERMINATED, afterSecond.Status.State)
+	assert.True(t, utils.IsImmutable(&afterSecond),
+		"cluster should be marked immutable once fully terminated")
 }


### PR DESCRIPTION
## Summary
Intent:
- The RayCluster controller monitors a launched cluster by fetching its status
  from the remote compute cluster. When the backing RayCluster has been deleted
  from the remote, GetJobClusterStatus returns NotFound and the controller
  requeued every 10s indefinitely, spinning on the log line
  "cluster not found on remote cluster, requeue" (controller.go:199).
- A cluster that has vanished from the remote is a terminal, non-recoverable
  condition: there is nothing left to monitor or clean up. The controller
  should record it and stop, not loop forever.
- Separately, RayCluster never marked itself immutable on reaching *any*
  terminal state (unlike RayJob/SparkJob, which do). A cluster that finished
  normally (killed, succeeded, failed) converged to Killed=TRUE/TERMINATED via
  the existing cleanup flow but stayed a live, mutable object in K8s/etcd
  indefinitely instead of being archived by the ingester.

Changes:
- On NotFound from the remote status fetch, mark the RayCluster as a terminal
  failure via the status subresource in one write (State=FAILED; Succeeded=FALSE
  with a reason/message; Killing=FALSE, Killed=TRUE). Setting the full terminal
  condition set directly (rather than just Succeeded=FALSE) means cleanupCluster
  will never issue a pointless DeleteJobCluster against a remote resource that's
  already confirmed gone.
- Added `isClusterFullyTerminal` + `markImmutableIfTerminal`: once a RayCluster's
  conditions show Succeeded decided and cleanup converged (Killing=FALSE,
  Killed=TRUE), it gets the `michelangelo/Immutable` annotation via a metadata
  Update. The ingester then moves the object to metadata storage and removes it
  from ETCD, so reconciliation stops permanently. This is checked after every
  `processClusterTermination` call, so it now covers **all** terminal paths
  (user/spec-driven kill, natural success/failure, creation failure) — not just
  NotFound-on-remote. It's a no-op while cleanup is still in flight (e.g.
  Killing=TRUE but Killed not yet TRUE); a later reconcile picks it back up.
- `markClusterFailedImmutable` (NotFound-on-remote) now delegates to
  `markImmutableIfTerminal` instead of duplicating the freeze logic, so there's
  a single place that decides when it's safe to freeze an object.
- Added unit test coverage: immutability assertions on all cleanup-convergence
  cases and the NotFound case, explicit non-immutability assertions on
  transient/in-flight states (guarding against freezing before cleanup actually
  runs), and a new multi-reconcile test proving the normal kill path converges
  to immutable over successive reconciles.

---

<sub>Generated by the 🪄 [pr-create](https://sg.uberinternal.com/code.uber.internal/uber-code/devexp-agent-marketplace/-/blob/claude-code/plugins/dev/uber-dev/skills/pr-create/SKILL.md) skill in devexp-agent-marketplace</sub>

## Test Plan

**Unit:** `bazel test //go/components/ray/cluster:go_default_test` passes — covers immutability across all terminal paths and non-immutability on transient/in-flight states.

**Live E2E** (OSS `k3d-michelangelo-sandbox`, `controllermgr` run locally, compute == control plane):

1. **Not-found-on-remote:** deleted a running cluster's backing KubeRay `ray.io` CR → controller logged `cluster not found on remote compute cluster, marking as failed`, set `State=FAILED / Succeeded=FALSE (ClusterNotFoundOnRemote) / Killing=FALSE / Killed=TRUE` + `michelangelo/Immutable`, then stopped requeuing.
2. **Success termination:** terminated a cluster with `TERMINATION_TYPE_SUCCEEDED` → `State=TERMINATED / Succeeded=TRUE / Killed=TRUE` + immutable; `cleanupCluster` deleted the KubeRay CR.
3. **Uniflow pipeline (Cadence `remote-run`):** ran a multi-task Ray pipeline end-to-end — workflow COMPLETED and all 9 task RayClusters reached `Succeeded=TRUE / Killed=TRUE` + `michelangelo/Immutable=true`.

Both terminal outcomes exercised — `Succeeded=TRUE` (success/kill) and `Succeeded=FALSE` (not-found) — 11 clusters total, each frozen immutable on reaching a terminal state.

## Issues


