### PR TITLE
docs(api-reference): add trainer modules to the Python SDK reference

### DIFF
--- a/docs/api-reference/python-sdk/index.md
+++ b/docs/api-reference/python-sdk/index.md
@@ -13,10 +13,7 @@ Start here if you're authoring pipelines with the Python SDK.
 > for what a task, a workflow, and Uniflow actually are before diving into the raw
 > signatures below.
 
-Some modules below aren't linked yet — coming soon. Two modules referenced elsewhere
-in this reference, the XGBoost trainer and `LightningTrainer` itself, aren't in the
-current generator config and have no page yet either; only the Torch collate-function
-utilities under **Trainer** are covered so far.
+Some modules below aren't linked yet — coming soon.
 
 ## Uniflow — Tasks & Workflows
 
@@ -55,13 +52,21 @@ The pusher component for CanvasFlex template-driven workflows.
 
 ## Trainer
 
-PyTorch training utilities used with `LightningTrainer` (`LightningTrainer` itself
-isn't generated into this reference yet — see the note above).
+Distributed trainers and the utilities used alongside them.
 
 | Module | Description |
 |--------|-------------|
+| [`lib.trainer.torch.pytorch_lightning.lightning_trainer`](reference/lib/trainer/torch/pytorch_lightning/lightning_trainer.md) | `LightningTrainer`, `LightningTrainerWithStateDict` and `LightningTrainerParam` |
+| [`lib.trainer.torch.pytorch_lightning.schema`](reference/lib/trainer/torch/pytorch_lightning/schema.md) | Warm-start schema types — `TransferLearningSpec`, `IncrementalTrainingSpec`, `ModelSpec`, `TrainingObserver`, `ExperimentStore` |
+| [`lib.trainer.torch.pytorch_lightning.experiment_store`](reference/lib/trainer/torch/pytorch_lightning/experiment_store.md) | `FsspecExperimentStore` — filesystem auto-resume backend |
+| [`lib.trainer.xgboost.xgboost_trainer`](reference/lib/trainer/xgboost/xgboost_trainer.md) | `XGBoostTrainer` and `XGBoostTrainerParam` |
 | [`lib.trainer.torch.data_collate_functions`](reference/lib/trainer/torch/data_collate_functions.md) | Collate functions for data loading |
 | `lib.trainer.torch.utils` | Trainer utilities |
+
+> Distributed strategy selection (DDP, FSDP, FSDP2) is passed through
+> `LightningTrainerParam.lightning_trainer_kwargs` to `pytorch_lightning.Trainer`, and the
+> strategy classes themselves are private, so they have no generated page here. See the
+> `lightning_trainer_kwargs` entry on `LightningTrainerParam` for how to set one.
 
 ## Native Transform
 

--- a/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/_category_.json
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "PyTorch Lightning",
+  "position": 1,
+  "collapsed": true
+}

--- a/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/experiment_store.md
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/experiment_store.md
@@ -1,0 +1,108 @@
+---
+sidebar_label: experiment_store
+title: michelangelo.lib.trainer.torch.pytorch_lightning.experiment_store
+---
+
+Default `schema.ExperimentStore` implementation for auto-resume.
+
+Public module: users import and construct `FsspecExperimentStore` and
+pass it as `LightningTrainerParam.experiment_store` to opt into auto-resume.
+See `michelangelo.lib.trainer.torch.pytorch_lightning.schema.ExperimentStore`
+for the seam it implements.
+
+## FsspecExperimentStore Objects
+
+```python
+class FsspecExperimentStore()
+```
+
+Filesystem-backed `schema.ExperimentStore` using an fsspec marker file.
+
+Persists a small JSON marker at a deterministic path so a re-run with the
+same `RunConfig(storage_path=..., name=...)` can locate and resume the
+previous run's experiment directory. Works with any fsspec scheme the
+`storage_path` selects (local, `s3://`, `gs://`, ...).
+
+The marker lives at `{storage_path}/.michelangelo_resume/{run_name}.json`
+rather than inside the Ray experiment directory, because that path is
+derivable purely from the stable `(storage_path, run_name)` identity and
+does not depend on Ray's (possibly timestamp-suffixed) experiment directory
+name. It inherits the same permissions and lifecycle as the run data it sits
+beside.
+
+Neither method raises: `track` logs and swallows any write failure,
+and `locate_resumable` returns `None` on a missing, corrupt, or
+unreadable marker. Staleness is not treated as an error — the trainer only
+seeds a resume when the recorded directory still holds a restorable Ray
+Train checkpoint, and otherwise starts fresh.
+
+**Attributes**:
+
+- `_MARKER_DIR` - Subdirectory (under `storage_path`) holding marker files.
+- `_SCHEMA_VERSION` - Marker payload schema version, for forward evolution.
+
+#### \_\_init\_\_
+
+```python
+def __init__(storage_options: dict | None = None) -> None
+```
+
+Initialize the store.
+
+**Arguments**:
+
+- `storage_options` - Optional keyword arguments forwarded to
+  `fsspec.core.url_to_fs` (e.g. credentials or endpoint
+  overrides for the backing filesystem). Kept as a plain dict so
+  the store remains picklable for transport to Ray workers.
+
+#### track
+
+```python
+def track(*, storage_path: str, run_name: str, experiment_path: str) -> None
+```
+
+Write the marker recording this run's experiment directory.
+
+Best-effort: any failure is logged and swallowed so a failed marker
+write can never fail an otherwise-successful training run. The payload
+is written to a temporary sibling file and atomically renamed into
+place, so a crash mid-write can never leave a partial/corrupt marker
+that a later `locate_resumable` would read.
+
+**Arguments**:
+
+- `storage_path` - The driver's `RunConfig.storage_path`.
+- `run_name` - The driver's `RunConfig.name`.
+- `experiment_path` - Absolute path (scheme-qualified for remote
+  filesystems, e.g. `s3://bucket/runs/my_run`) of this run's Ray
+  Train experiment directory.
+  
+
+**Returns**:
+
+`None`.
+
+#### locate\_resumable
+
+```python
+def locate_resumable(*, storage_path: str, run_name: str) -> str | None
+```
+
+Read the marker and return the recorded experiment path, or `None`.
+
+Returns `None` (never raises) when the marker is missing, corrupt, or
+unreadable, or when it carries no `experiment_path`. A missing or
+corrupt marker is the normal "nothing to resume yet" case and is logged
+at `DEBUG`; only genuinely unexpected filesystem errors are logged at
+`WARNING`.
+
+**Arguments**:
+
+- `storage_path` - The driver's `RunConfig.storage_path`.
+- `run_name` - The driver's `RunConfig.name`.
+
+**Returns**:
+
+The recorded candidate experiment directory, or `None`.
+

--- a/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/lightning_trainer.md
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/lightning_trainer.md
@@ -1,0 +1,183 @@
+---
+sidebar_label: lightning_trainer
+title: michelangelo.lib.trainer.torch.pytorch_lightning.lightning_trainer
+---
+
+Public PyTorch Lightning trainer wrapping Ray Train.
+
+This package is a one-time snapshot of an internal trainer used for distributed
+PyTorch Lightning training on Ray. Bugs may be patched in OSS, but new features
+are not automatically backported from the source. See `CONTRIBUTING.md` for
+the support policy.
+
+Typical use:
+
+```python
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    LightningTrainer,
+    LightningTrainerParam,
+)
+
+trainer = LightningTrainer(
+    trainer_param=LightningTrainerParam(
+        create_model_fn=my_model_factory,
+        create_model_fn_kwargs={"hidden_dim": 64},
+        train_data=train_ds,
+        val_data=val_ds,
+        batch_size=256,
+    ),
+    run_config=ray.train.RunConfig(name="my_run", storage_path="/tmp/runs"),
+    scaling_config=ray.train.ScalingConfig(num_workers=1, use_gpu=False),
+)
+result = trainer.train()
+```
+## LightningTrainerParam Objects
+
+```python
+@dataclass
+class LightningTrainerParam()
+```
+
+Configuration for `LightningTrainer`.
+
+All callables (`create_model_fn`, `data_collate_fn`) are invoked inside the
+Ray Train worker. The model is constructed on each worker via
+`create_model_fn(**create_model_fn_kwargs)` rather than being pickled across
+process boundaries.
+
+**Attributes**:
+
+- `create_model_fn` - Factory returning a `pytorch_lightning.LightningModule`. Invoked on each
+  worker with `**create_model_fn_kwargs`.
+- `create_model_fn_kwargs` - Keyword arguments passed to `create_model_fn`.
+- `train_data` - Training Ray Dataset.
+- `val_data` - Validation Ray Dataset.
+- `batch_size` - Per-worker training batch size.
+- `num_shuffle_batches` - Number of batches kept in the Ray Data local shuffle buffer. `0` disables
+  shuffling.
+- `num_epochs` - Deprecated; prefer `lightning_trainer_kwargs={"max_epochs": N}`.
+- `data_collate_fn` - Optional custom collate function passed to `Dataset.iter_torch_batches`;
+  defaults to Ray Data's column-tensor output.
+- `lightning_trainer_kwargs` - Extra keyword arguments forwarded verbatim to
+  `pytorch_lightning.Trainer(...)`.
+- `transfer_learning_spec` - Optional warm-start spec describing layer freezing patterns.
+- `incremental_training_spec` - Optional spec for continuing from an existing run.
+- `initial_weights_path` - Optional path to a state dict file (local, `s3://`, `gs://`, etc.); loaded on
+  rank 0 and broadcast to other workers.
+- `training_observer` - Optional `schema.TrainingObserver` that receives `on_result` (driver-side,
+  after training) and `on_checkpoint_saved` (worker-side, per epoch/step). Must
+  be picklable if per-epoch observation is needed.
+- `experiment_store` - Optional `schema.ExperimentStore` enabling opt-in auto-resume. When set (and
+  `run_config` carries both a `name` and a `storage_path`), the trainer records
+  this run's experiment directory on rank 0 and, on a re-run with the same
+  identity, seeds training from the previously recorded directory if it holds a
+  restorable checkpoint. Note that Ray Train V2 also resumes natively from a
+  reused run directory (`storage_path/name`); the store additionally covers the
+  case where Ray's native checkpoint state is unavailable and provides a
+  pluggable, backend-agnostic record of resumable runs. Defaults to `None` (no
+  tracking, no store-driven resume). Use
+  `experiment_store.FsspecExperimentStore` for the filesystem default. Must be
+  picklable (serialized to workers for tracking).
+- `profiler_sink` - Optional callable invoked on each node-local rank 0 after `fit()` returns, as
+  `profiler_sink(profiler, profiler_logs_path, logger)`, where `profiler` is the
+  profiler built from `lightning_trainer_kwargs["profiler"]`,
+  `profiler_logs_path` is the directory it wrote to, and `logger` is the
+  resolved Lightning logger. Use it to ship profiler output to an experiment
+  tracker; `_private.util.comet_profiler_sink` does this for Comet and
+  `_private.util.mlflow_profiler_sink` does this for MLflow. Ignored when no
+  profiler is configured or when the profiler config sets
+  `upload_profiler_results: False`. Exceptions raised by the sink are logged and
+  swallowed. Must be picklable (serialized to workers).
+
+#### num\_epochs
+
+type: ignore[assignment]  # sentinel replaced in __post_init__
+
+#### \_\_post\_init\_\_
+
+```python
+def __post_init__()
+```
+
+Apply default `num_epochs` and warn on the deprecated field usage.
+
+## LightningTrainer Objects
+
+```python
+class LightningTrainer(TorchTrainer)
+```
+
+Ray `TorchTrainer` subclass that runs a PyTorch Lightning training loop.
+
+#### \_\_init\_\_
+
+```python
+def __init__(trainer_param: LightningTrainerParam,
+             run_config: ray.train.RunConfig | None = None,
+             scaling_config: ray.train.ScalingConfig | None = None)
+```
+
+Initialize the trainer.
+
+**Arguments**:
+
+- `trainer_param` - Training configuration (model factory, datasets, etc.).
+- `run_config` - Optional Ray `RunConfig` (storage path, run name, ...).
+- `scaling_config` - Optional Ray `ScalingConfig` (num_workers, GPU/CPU
+  requests, ...).
+
+#### train
+
+```python
+def train(run_config: ray.train.RunConfig | None = None,
+          scaling_config: ray.train.ScalingConfig | None = None) -> dict
+```
+
+Run training and return a small result dict.
+
+**Arguments**:
+
+- `run_config` - Optional override applied before `fit()`.
+- `scaling_config` - Optional override applied before `fit()`.
+  
+
+**Returns**:
+
+Dict with `checkpoint_path` (path to the latest checkpoint), `path` (the Ray
+result path), and `metrics`.
+  
+
+**Raises**:
+
+Exception: Whatever Ray Train reports in `result.error`.
+
+## LightningTrainerWithStateDict Objects
+
+```python
+class LightningTrainerWithStateDict(LightningTrainer)
+```
+
+LightningTrainer that loads the trained checkpoint into a torch model.
+
+After `train()` completes, callers can pass an initialized `torch.nn.Module`
+to `update_model_state_dict` and have it populated from the latest
+checkpoint. Supports DDP single-file checkpoints, DeepSpeed ZeRO sharded
+directories, and FSDP2 distributed checkpoints.
+
+#### update\_model\_state\_dict
+
+```python
+def update_model_state_dict(torch_model: torch.nn.Module) -> None
+```
+
+Populate `torch_model` in-place from the latest training checkpoint.
+
+**Arguments**:
+
+- `torch_model` - Model whose `state_dict` will be replaced.
+  
+
+**Raises**:
+
+ValueError: If `train()` has not been called yet.
+

--- a/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/schema.md
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/torch/pytorch_lightning/schema.md
@@ -1,0 +1,321 @@
+---
+sidebar_label: schema
+title: michelangelo.lib.trainer.torch.pytorch_lightning.schema
+---
+
+Schema dataclasses used by the Lightning trainer.
+
+## TrainingObserver Objects
+
+```python
+@runtime_checkable
+class TrainingObserver(Protocol)
+```
+
+Protocol for observing training events.
+
+Implement this protocol to receive notifications when training completes
+or checkpoints are saved.
+
+**Picklability:** Implementations must be picklable when using per-epoch
+observation (`on_checkpoint_saved`), because Ray serializes the training
+config — including the observer — to worker processes. Avoid storing
+non-picklable objects (open file handles, DB connections, lambdas) as
+instance attributes.
+
+**Worker-side behavior:** `on_checkpoint_saved` is called on **every**
+Ray worker (all ranks), not just rank 0. Implementations should be
+idempotent or guard on rank internally if side effects (DB writes,
+HTTP calls) should only happen once.
+
+Example::
+
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+LightningTrainer,
+LightningTrainerParam,
+TrainingObserver,
+)
+
+class MyObserver:
+def on_result(self, metrics: dict[str, Any], checkpoint_path: str | None) -> None:
+print(f"Training done: {metrics}")
+
+def on_checkpoint_saved(
+self, epoch: int, step: int, metrics: dict[str, Any], checkpoint_path: str,
+) -> None:
+print(f"Checkpoint at epoch {epoch}")
+
+trainer = LightningTrainer(
+trainer_param=LightningTrainerParam(
+create_model_fn=my_model_factory,
+train_data=train_ds,
+val_data=val_ds,
+training_observer=MyObserver(),
+),
+)
+
+#### on\_result
+
+```python
+def on_result(metrics: dict[str, Any], checkpoint_path: str | None) -> None
+```
+
+Called on the driver after training completes successfully.
+
+**Arguments**:
+
+- `metrics` - Final training metrics dict.
+- `checkpoint_path` - Path to the final checkpoint, or `None` if no
+  checkpoint was saved.
+
+#### on\_checkpoint\_saved
+
+```python
+def on_checkpoint_saved(epoch: int, step: int, metrics: dict[str, Any],
+                        checkpoint_path: str) -> None
+```
+
+Called on each worker after a checkpoint is saved and reported.
+
+Note: this is called on **all** workers, not just rank 0.
+The `checkpoint_path` is a local temporary path that may be
+cleaned up shortly after this method returns.
+
+**Arguments**:
+
+- `epoch` - Current training epoch.
+- `step` - Current global step.
+- `metrics` - Metrics dict reported with the checkpoint.
+- `checkpoint_path` - Local path where the checkpoint was saved.
+
+## ExperimentStore Objects
+
+```python
+@runtime_checkable
+class ExperimentStore(Protocol)
+```
+
+Pluggable locator for resumable Ray Train experiments.
+
+An `ExperimentStore` lets `LightningTrainer` auto-resume a prior
+run's experiment directory. It bridges two moments that live in different
+processes:
+
+* `track` runs **on the worker (rank 0 only)** at the start of a run,
+  recording where this run's Ray Train experiment directory lives so a
+  *future* run can find it.
+* `locate_resumable` runs **on the driver** before `fit()`, looking
+  up a candidate experiment directory to restore from.
+
+The stable cross-run identity is `(storage_path, run_name)` — both taken
+from the driver's `RunConfig` and passed verbatim to both methods, so the
+two sides always agree on the key regardless of how Ray names the on-disk
+experiment directory.
+
+**Picklability:** implementations must be picklable — Ray serializes the
+training config (including this store) to worker processes for
+`track`. Avoid open file handles, DB connections, or lambdas as
+instance attributes (same constraint as `TrainingObserver`).
+
+**Never raise:** neither method may raise on the "nothing to resume" or
+"couldn't persist" paths. `locate_resumable` returns `None` when
+there is nothing to resume; `track` is best-effort (a failed write
+must not fail an otherwise-successful training run). The trainer additionally
+guards both call sites, so a misbehaving custom store cannot crash training.
+
+Example (default fsspec backend):
+
+```python
+from michelangelo.lib.trainer.torch.pytorch_lightning import (
+    FsspecExperimentStore,
+    LightningTrainerParam,
+)
+
+param = LightningTrainerParam(
+    create_model_fn=my_model_factory,
+    create_model_fn_kwargs={},
+    train_data=train_ds,
+    val_data=val_ds,
+    experiment_store=FsspecExperimentStore(),
+)
+```
+Example (bring your own backend):
+
+```python
+class RedisExperimentStore:
+    """Record the resume pointer in Redis instead of a marker file."""
+
+    def __init__(self, client) -> None:
+        self._client = client
+
+    def _key(self, storage_path: str, run_name: str) -> str:
+        return f"ma-resume:{storage_path}:{run_name}"
+
+    def track(
+        self, *, storage_path: str, run_name: str, experiment_path: str
+    ) -> None:
+        try:
+            self._client.set(
+                self._key(storage_path, run_name), experiment_path
+            )
+        except Exception:  # best-effort: never fail training
+            pass
+
+    def locate_resumable(
+        self, *, storage_path: str, run_name: str
+    ) -> str | None:
+        try:
+            value = self._client.get(self._key(storage_path, run_name))
+        except Exception:  # nothing to resume on any lookup failure
+            return None
+        return value.decode() if value else None
+```
+#### track
+
+```python
+def track(*, storage_path: str, run_name: str, experiment_path: str) -> None
+```
+
+Record this run's experiment directory for future resumption.
+
+Called once, on worker rank 0, near the start of training.
+
+**Arguments**:
+
+- `storage_path` - The driver's `RunConfig.storage_path` (the storage
+  root; also the fsspec root under which markers are kept).
+- `run_name` - The driver's `RunConfig.name` (stable run identity).
+- `experiment_path` - Absolute path of *this* run's Ray Train experiment
+  directory, derived by the caller from the driver's
+  `RunConfig.storage_path` and
+  `ray.train.get_context().get_storage().experiment_dir_name`.
+  Scheme-qualified for remote filesystems (e.g.
+  `s3://bucket/runs/my_run`) so a later resume can address it.
+  
+
+**Returns**:
+
+`None`.
+
+#### locate\_resumable
+
+```python
+def locate_resumable(*, storage_path: str, run_name: str) -> str | None
+```
+
+Return a candidate experiment directory to resume, or `None`.
+
+Called on the driver before `fit()`. The returned path is only a
+*candidate*: the trainer resolves the latest Ray Train checkpoint within
+it and seeds resumption only if one exists, so this method must not
+itself check for a valid checkpoint. Returns `None` when no marker
+exists or it cannot be read.
+
+**Arguments**:
+
+- `storage_path` - The driver's `RunConfig.storage_path`.
+- `run_name` - The driver's `RunConfig.name`.
+  
+
+**Returns**:
+
+A candidate experiment directory path, or `None` when there is nothing to
+resume.
+
+## TrainingType Objects
+
+```python
+class TrainingType(Enum)
+```
+
+Enum for training types in incremental training.
+
+## LearningMode Objects
+
+```python
+class LearningMode(Enum)
+```
+
+Enum for learning modes in transfer learning.
+
+## ModelSpec Objects
+
+```python
+@dataclass
+class ModelSpec()
+```
+
+A reference to a model that may be loaded for incremental training or transfer learning.
+
+## IncrementalTrainingMetadata Objects
+
+```python
+@dataclass
+class IncrementalTrainingMetadata()
+```
+
+Metadata for incremental training.
+
+## IncrementalTrainingSpec Objects
+
+```python
+@dataclass
+class IncrementalTrainingSpec()
+```
+
+Consolidated specification for all incremental training configurations.
+
+**Attributes**:
+
+- `metadata` - Baseline model and training-type metadata for this run.
+- `load_optimizer_weights` - Whether to restore optimizer state from the baseline checkpoint in addition to
+  model weights.
+- `override_incremental_training_epoch` - Explicit starting epoch for the incremental run. `None` continues from the
+  baseline's own epoch count.
+- `fused_model_submodule` - Optional submodule-prefix used to select a slice of a fused checkpoint's
+  combined state dict before loading it (e.g. `"predictor_module"` for the DL
+  predictor half of a fused native-transform package). Schema-only in OSS today
+  — carried through for forward compatibility with internal Michelangelo's warm-
+  start config shape; no OSS code currently strips or consumes this prefix.
+  Defaults to `None` here, unlike internal Michelangelo's `"predictor_module"`
+  default — reconcile this divergence deliberately once OSS implements the
+  stripping behavior (see the PR that ports it).
+
+## TransferLearningMetadata Objects
+
+```python
+@dataclass
+class TransferLearningMetadata()
+```
+
+Metadata for transfer learning.
+
+## TransferLearningSpec Objects
+
+```python
+@dataclass
+class TransferLearningSpec()
+```
+
+Consolidated specification for all transfer learning configurations.
+
+**Attributes**:
+
+- `metadata` - Baseline model and learning-mode metadata for this run.
+- `model_loader_function` - Optional dotted path to a custom function for loading the baseline model,
+  overriding the default loader.
+- `layer_names_to_inherit` - Exact layer names to copy weights for from the baseline model.
+- `layer_names_to_inherit_regex` - Regex patterns matching layer names to copy weights for from the baseline
+  model.
+- `layer_names_to_freeze` - Exact layer names to freeze (exclude from gradient updates) after loading
+  baseline weights.
+- `layer_names_to_freeze_regex` - Regex patterns matching layer names to freeze after loading baseline weights.
+- `fused_model_submodule` - Optional submodule-prefix used to select a slice of a fused checkpoint's
+  combined state dict before loading it (e.g. `"predictor_module"` for the DL
+  predictor half of a fused native-transform package). Schema-only in OSS today
+  — carried through for forward compatibility with internal Michelangelo's warm-
+  start config shape; no OSS code currently strips or consumes this prefix.
+  Defaults to `None` here, unlike internal Michelangelo's `"predictor_module"`
+  default — reconcile this divergence deliberately once OSS implements the
+  stripping behavior (see the PR that ports it).
+

--- a/docs/api-reference/python-sdk/reference/lib/trainer/xgboost/_category_.json
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/xgboost/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "XGBoost",
+  "position": 2,
+  "collapsed": true
+}

--- a/docs/api-reference/python-sdk/reference/lib/trainer/xgboost/xgboost_trainer.md
+++ b/docs/api-reference/python-sdk/reference/lib/trainer/xgboost/xgboost_trainer.md
@@ -1,0 +1,127 @@
+---
+sidebar_label: xgboost_trainer
+title: michelangelo.lib.trainer.xgboost.xgboost_trainer
+---
+
+Public XGBoost trainer wrapping Ray Train.
+
+Distributed, data-parallel XGBoost training on a Ray cluster, exposed with the
+same shape as the PyTorch Lightning trainer in
+`michelangelo.lib.trainer.torch.pytorch_lightning`: a parameter dataclass, a
+`train()` that returns a small result dict, and checkpointing handled by Ray
+Train's own report callback.
+
+Typical use:
+
+```python
+from michelangelo.lib.trainer.xgboost import (
+    XGBoostTrainer,
+    XGBoostTrainerParam,
+)
+
+trainer = XGBoostTrainer(
+    trainer_param=XGBoostTrainerParam(
+        label_column="target",
+        train_data=train_ds,
+        val_data=val_ds,
+        params={"objective": "reg:squarederror", "eta": 0.1},
+        num_boost_round=50,
+    ),
+    run_config=ray.train.RunConfig(name="my_run", storage_path="/tmp/runs"),
+    scaling_config=ray.train.ScalingConfig(num_workers=2, use_gpu=False),
+)
+result = trainer.train()
+print(result["checkpoint_path"])
+```
+## XGBoostTrainerParam Objects
+
+```python
+@dataclass
+class XGBoostTrainerParam()
+```
+
+Configuration for `XGBoostTrainer`.
+
+**Attributes**:
+
+- `label_column` - Name of the target column. Must be present in `train_data` and, when supplied,
+  `val_data`.
+- `train_data` - Training Ray Dataset.
+- `val_data` - Optional validation Ray Dataset. When omitted, training runs with the training
+  set as its only eval set.
+- `params` - XGBoost booster parameters, passed verbatim as the first argument to
+  `xgboost.train` (for example `{"objective": "reg:squarederror", "eta": 0.1}`).
+- `num_boost_round` - Number of boosting rounds.
+- `feature_columns` - Explicit feature column names. When `None` (the default), every column except
+  `label_column` is used as a feature.
+- `xgboost_train_kwargs` - Extra keyword arguments forwarded verbatim to `xgboost.train(...)`.
+  `callbacks` is reserved -- the trainer supplies Ray Train's report callback,
+  so passing your own here raises `ValueError` rather than silently losing
+  checkpointing.
+
+#### \_\_post\_init\_\_
+
+```python
+def __post_init__() -> None
+```
+
+Reject configurations that would silently drop checkpointing.
+
+**Raises**:
+
+- `ValueError` - If `label_column` is empty, `num_boost_round` is
+  not positive, or `xgboost_train_kwargs` carries `callbacks`
+  (which would collide with the report callback the trainer
+  installs).
+
+## XGBoostTrainer Objects
+
+```python
+class XGBoostTrainer(RayXGBoostTrainer)
+```
+
+Ray `XGBoostTrainer` subclass running a data-parallel XGBoost fit.
+
+#### \_\_init\_\_
+
+```python
+def __init__(trainer_param: XGBoostTrainerParam,
+             run_config: ray.train.RunConfig | None = None,
+             scaling_config: ray.train.ScalingConfig | None = None)
+```
+
+Initialize the trainer.
+
+**Arguments**:
+
+- `trainer_param` - Training configuration (label, datasets, booster
+  params, ...).
+- `run_config` - Optional Ray `RunConfig` (storage path, run name, ...).
+- `scaling_config` - Optional Ray `ScalingConfig` (num_workers, GPU/CPU
+  requests, ...).
+
+#### train
+
+```python
+def train(run_config: ray.train.RunConfig | None = None,
+          scaling_config: ray.train.ScalingConfig | None = None) -> dict
+```
+
+Run training and return a small result dict.
+
+**Arguments**:
+
+- `run_config` - Optional override applied before `fit()`.
+- `scaling_config` - Optional override applied before `fit()`.
+  
+
+**Returns**:
+
+Dict with `checkpoint_path` (path to the latest checkpoint, or `None` if the run
+reported none), `path` (the Ray result path), and `metrics`.
+  
+
+**Raises**:
+
+Exception: Whatever Ray Train reports in `result.error`.
+

--- a/pydoc-markdown.yml
+++ b/pydoc-markdown.yml
@@ -18,6 +18,10 @@ loaders:
       - workflow.tasks.pusher.exceptions
       - lib.trainer.torch.data_collate_functions
       - lib.trainer.torch.utils
+      - lib.trainer.torch.pytorch_lightning.lightning_trainer
+      - lib.trainer.torch.pytorch_lightning.schema
+      - lib.trainer.torch.pytorch_lightning.experiment_store
+      - lib.trainer.xgboost.xgboost_trainer
       - lib.native_transform.torch.base_layers
       - lib.native_transform.torch.id_hash_tokenizer
       - lib.native_transform.torch.utils


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

**What changed?**

Adds the two trainers to the Python SDK reference that #1956 established, plus the two supporting modules they reference:

| Module | Covers |
|---|---|
| `lib.trainer.torch.pytorch_lightning.lightning_trainer` | `LightningTrainer`, `LightningTrainerWithStateDict`, `LightningTrainerParam` |
| `lib.trainer.torch.pytorch_lightning.schema` | `TransferLearningSpec`, `IncrementalTrainingSpec`, `ModelSpec`, `TrainingObserver`, `ExperimentStore` |
| `lib.trainer.torch.pytorch_lightning.experiment_store` | `FsspecExperimentStore` |
| `lib.trainer.xgboost.xgboost_trainer` | `XGBoostTrainer`, `XGBoostTrainerParam` |

The index's **Trainer** section links all four, and the note saying the XGBoost trainer and `LightningTrainer` "aren't in the current generator config and have no page yet" is removed, since that is no longer true.

**Why?**

`XGBoostTrainer` has had no documentation anywhere in `docs/` since it merged in #1793, and `LightningTrainer` — the SDK's primary training entry point — had no reference page either, even though other pages refer to it. The generated index was itself flagging both as missing.

**How did you test it?**

- Every rendered bullet name was checked back against the source docstrings; 52/52 trace to real `Attributes:`/`Args:` entries. No prose was invented for these pages.
- Ran the `docs-check.yml` relative-link rule (`grep -rEn '\]\(\.\.?/' docs/ --include='*.md'` minus the skip patterns) — clean, both for the new files and repo-wide.
- Verified every relative link added to `index.md` resolves to a file on disk.

**Potential risks**

Documentation only — no code paths, no build or deployment changes.

---

**Two things worth a reviewer's attention**

**1. The committed reference pages are not reproducible from `bun run docs:api`.** Running the documented command on current `main` (pydoc-markdown 4.8.2, the latest release) does not reproduce the 10 pages already committed. The committed pages have Sphinx roles converted to Markdown (`` :func:`x` `` → `` `x` ``), a `michelangelo.` prefix on `title:`, `_category_.json` sidebar files, and at least one `**Example**:` code block that does not exist in the source docstring. Stock generation produces none of those. So the existing pages were generated once and then polished by hand.

That matters because the index tells contributors to regenerate after editing docstrings. Doing so today would strip the hand-polish, revert roles to raw `:func:` text that renders literally on the docs site, and drop the sidebar files.

**2. The Google-style section parser corrupts these docstrings.** On the four modules here, stock generation mangled 31 lines across all four pages into indexed placeholders — e.g. `` - ```label_column`2 - "reg:squarederror", "eta": 0.1}``). `` and `` - ``0 - Extra keyword arguments... ``. The trigger is an attribute description containing a colon inside a literal, such as `params`' example value `{"objective": "reg:squarederror", "eta": 0.1}`, which the parser reads as the start of a new field.

I rebuilt the affected `Attributes:`/`Args:`/`Returns:` blocks directly from the source docstrings rather than hand-patching the corrupted output, which is why the bullet-name verification above was worth running.

Net effect: this PR follows the existing convention (generate, then correct), but that convention is undocumented and silently lossy. Worth a follow-up issue to either pin a working toolchain and make generation truly reproducible, or state plainly that these pages are hand-maintained and stop advertising a regeneration command that damages them. Happy to file that separately.

**Also unblocked by this PR:** re-running generation on current `main` yields 21 pages against the 10 committed, because #1955's docstring fixes made 11 previously-`skip_empty_modules`-skipped modules renderable and nobody re-ran the generator afterward. I deliberately left those 11 out of this PR — they have never been reviewed and would need the same correction pass. Flagging so it is a decision rather than an oversight.

**Breaking Changes**

- [x] No breaking changes

**Documentation Changes**

- `pydoc-markdown.yml` — 4 trainer modules added to the loader
- `docs/api-reference/python-sdk/index.md` — Trainer section links the new pages; stale "no page yet" note removed; note added on DDP/FSDP/FSDP2 strategy selection
- `docs/api-reference/python-sdk/reference/lib/trainer/{xgboost,torch/pytorch_lightning}/` — 4 new pages + 2 `_category_.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
