### PR TITLE
fix(python): correct and de-internalize public trainer docstrings

### DIFF
--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/lightning_trainer.py
@@ -34,7 +34,7 @@ import os
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass, field
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import ray
 import torch
@@ -69,7 +69,10 @@ CHECKPOINT_PATH_KEY = "checkpoint_path"
 # public ``Result.from_path`` is unimplemented and ``can_restore`` /
 # ``resume_from_checkpoint`` are deprecated.
 _CHECKPOINT_MANAGER_SNAPSHOT_FILENAME = "checkpoint_manager_snapshot.json"
-_UNSET = object()
+# Sentinel distinguishing "num_epochs never set" from an explicit None; replaced
+# with the real default in ``LightningTrainerParam.__post_init__``. Typed as Any
+# so it can stand in for the annotated field types it defaults.
+_UNSET: Any = object()
 
 
 @dataclass
@@ -126,8 +129,9 @@ class LightningTrainerParam:
             ``lightning_trainer_kwargs["profiler"]``, ``profiler_logs_path`` is
             the directory it wrote to, and ``logger`` is the resolved Lightning
             logger. Use it to ship profiler output to an experiment tracker;
-            :func:`~_private.util.comet_profiler_sink` does this for Comet and
-            :func:`~_private.util.mlflow_profiler_sink` does this for MLflow.
+            ``comet_profiler_sink`` does this for Comet and
+            ``mlflow_profiler_sink`` does this for MLflow (both importable from
+            ``michelangelo.lib.trainer.torch.pytorch_lightning``).
             Ignored when no profiler is configured or when the profiler config
             sets ``upload_profiler_results: False``. Exceptions raised by the sink are
             logged and swallowed. Must be picklable (serialized to workers).
@@ -141,7 +145,7 @@ class LightningTrainerParam:
     num_shuffle_batches: int = (
         10  # By default we reserve 10 batches in ray data shuffle buffer.
     )
-    num_epochs: int | None = field(default=_UNSET)  # type: ignore[assignment]  # sentinel replaced in __post_init__
+    num_epochs: int | None = field(default=_UNSET)
     data_collate_fn: Callable | None = None
     lightning_trainer_kwargs: dict = field(default_factory=dict)
 

--- a/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
+++ b/python/michelangelo/lib/trainer/torch/pytorch_lightning/schema.py
@@ -25,7 +25,7 @@ class TrainingObserver(Protocol):
     idempotent or guard on rank internally if side effects (DB writes,
     HTTP calls) should only happen once.
 
-    Example::
+    Example (observing training events)::
 
         from michelangelo.lib.trainer.torch.pytorch_lightning import (
             LightningTrainer,
@@ -246,21 +246,20 @@ class IncrementalTrainingSpec:
         override_incremental_training_epoch: Explicit starting epoch for the
             incremental run. ``None`` continues from the baseline's own epoch
             count.
-        fused_model_submodule: Optional submodule-prefix used to select a
-            slice of a fused checkpoint's combined state dict before loading
-            it (e.g. ``"predictor_module"`` for the DL predictor half of a
-            fused native-transform package). Schema-only in OSS today —
-            carried through for forward compatibility with internal
-            Michelangelo's warm-start config shape; no OSS code currently
-            strips or consumes this prefix. Defaults to ``None`` here,
-            unlike internal Michelangelo's ``"predictor_module"`` default —
-            reconcile this divergence deliberately once OSS implements the
-            stripping behavior (see the PR that ports it).
+        fused_model_submodule: Reserved for future use; has no effect today.
+            Intended as a submodule-prefix selecting a slice of a fused
+            checkpoint's combined state dict before loading it (e.g.
+            ``"predictor_module"`` for the DL predictor half of a fused
+            native-transform package). Nothing currently reads it — leave it
+            unset.
     """
 
     metadata: IncrementalTrainingMetadata
     load_optimizer_weights: bool = False
     override_incremental_training_epoch: int | None = None
+    # Maintainer note: defaults to None here, where internal Michelangelo AI
+    # defaults to "predictor_module". Reconcile this divergence deliberately if
+    # and when the prefix-stripping behavior is implemented here.
     fused_model_submodule: str | None = None
 
 
@@ -288,16 +287,12 @@ class TransferLearningSpec:
             gradient updates) after loading baseline weights.
         layer_names_to_freeze_regex: Regex patterns matching layer names to
             freeze after loading baseline weights.
-        fused_model_submodule: Optional submodule-prefix used to select a
-            slice of a fused checkpoint's combined state dict before loading
-            it (e.g. ``"predictor_module"`` for the DL predictor half of a
-            fused native-transform package). Schema-only in OSS today —
-            carried through for forward compatibility with internal
-            Michelangelo's warm-start config shape; no OSS code currently
-            strips or consumes this prefix. Defaults to ``None`` here,
-            unlike internal Michelangelo's ``"predictor_module"`` default —
-            reconcile this divergence deliberately once OSS implements the
-            stripping behavior (see the PR that ports it).
+        fused_model_submodule: Reserved for future use; has no effect today.
+            Intended as a submodule-prefix selecting a slice of a fused
+            checkpoint's combined state dict before loading it (e.g.
+            ``"predictor_module"`` for the DL predictor half of a fused
+            native-transform package). Nothing currently reads it — leave it
+            unset.
     """
 
     metadata: TransferLearningMetadata
@@ -307,4 +302,7 @@ class TransferLearningSpec:
     layer_names_to_inherit_regex: list[str] = field(default_factory=list)
     layer_names_to_freeze: list[str] = field(default_factory=list)
     layer_names_to_freeze_regex: list[str] = field(default_factory=list)
+    # Maintainer note: defaults to None here, where internal Michelangelo AI
+    # defaults to "predictor_module". Reconcile this divergence deliberately if
+    # and when the prefix-stripping behavior is implemented here.
     fused_model_submodule: str | None = None


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Corrects four problems in public docstrings under
`python/michelangelo/lib/trainer/torch/pytorch_lightning/`. These docstrings are
the generation source for the Python SDK Reference, so their contents ship to the
public docs site.

- **`fused_model_submodule` (both warm-start specs)** — described an internal
  counterpart system by name and told readers to "see the PR that ports it", which
  an external reader cannot find. Reworded to state what the field does today
  (nothing — it is reserved). The default-value divergence is preserved as a
  maintainer code comment on the field itself, so the information isn't lost.
- **`TrainingObserver` example** — used a bare ``Example::`` literal block, which
  the generator fails to convert: the rendered page lost its code block and *all*
  indentation, leaving Python that cannot be copied. Switched to the
  parenthesized form already used twice in this same file, which converts
  correctly.
- **`profiler_sink`** — pointed at `_private.util.comet_profiler_sink`. The sinks
  actually live in `_private.profiler`, and `_private` is not a public import
  path. Now references the public re-export.
- **`num_epochs`** — carried a trailing `# sentinel replaced in __post_init__`
  comment that the generator emitted as a stray documented attribute exposing an
  internal sentinel. Annotating `_UNSET` as `Any` removes the need for the
  `type: ignore`, and the explanation moves to the sentinel's own definition.

<!-- Tell your future self why have you made these changes -->
**Why?**

#2007 adds these modules to the generated Python SDK Reference. Reviewing that PR
surfaced these issues in the generated output, but every one of them originates in
the source docstrings rather than the generator — so they are fixed here, at the
source, rather than hand-patched in generated markdown that the next regeneration
would overwrite.

Two of the four are correctness issues rather than style: the `profiler_sink`
module path is simply wrong, and the internal-system reference is a trademark and
public-docs concern.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- `ruff check` and `ruff format --diff` pass on both changed files.
- Confirmed `schema.py` still imports on Python 3.11 and that every dataclass
  field and default is unchanged (`TransferLearningSpec` and
  `IncrementalTrainingSpec` constructed and asserted field-by-field).
- Verified the example fix empirically with a controlled A/B: generated the page
  from the pre-change and post-change docstring using the same pydoc-markdown
  version. Before, every line of the example rendered at zero indentation
  (a paragraph, with `{metrics}` exposed as body text); after, the block renders
  at 4/8-space indentation as a proper code block.
- Confirmed the stray `num_epochs` attribute no longer appears in generated output.

No unit tests added — the change is comments, docstrings, and one annotation on a
module-private sentinel.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None. `git diff` contains no logic changes: the only non-comment edits are adding
`Any` to a `typing` import and annotating the module-private `_UNSET` sentinel,
neither of which affects runtime behavior.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki -->
**Documentation Changes**

This PR *is* the documentation change — it corrects the docstrings that generate
the Python SDK Reference. No `docs/` files are touched here; #2007 should be
regenerated on top of this so the corrections land in the published reference.
