### PR TITLE
feat(ui): Render stages as pending

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
+import { TASK_STATE } from '#core/components/views/execution/constants';
+import { DEPLOYMENT_DETAIL_CONFIG } from '#core/config/entities/deployment/detail';
 import {
   DEPLOYMENT_CONDITION_STATUS,
   DEPLOYMENT_STAGE,
@@ -16,6 +18,8 @@ import {
   createQueryMockRouter,
   getServiceProviderWrapper,
 } from '#core/test/wrappers/get-service-provider-wrapper';
+
+import type { ExecutionDetailPageConfig } from '#core/components/views/detail-view/types/detail-view-schema-types';
 
 describe('Deployment list page', () => {
   it('renders the Deployments tab', () => {
@@ -417,6 +421,168 @@ describe('Deployment detail page', () => {
       await screen.findAllByText('SnapshotValidation');
       await screen.findAllByText('SnapshotPlacement');
       await screen.findByText('NoCapacity');
+    });
+
+    it('renders a state chip per condition mapped from the condition status', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: buildDeployment({
+                  status: {
+                    state: DEPLOYMENT_STATE.INITIALIZING,
+                    stage: DEPLOYMENT_STAGE.PLACEMENT,
+                    conditions: [
+                      { type: 'Validated', status: DEPLOYMENT_CONDITION_STATUS.TRUE },
+                      { type: 'Placement', status: DEPLOYMENT_CONDITION_STATUS.UNKNOWN },
+                      { type: 'RolloutCompleted', status: DEPLOYMENT_CONDITION_STATUS.FALSE },
+                    ],
+                  },
+                }),
+              },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('Succeeded')).toBeInTheDocument();
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+      expect(screen.getByText('Running')).toBeInTheDocument();
+    });
+
+    it('falls back to live conditions when a failed rollout has an empty snapshot', async () => {
+      render(
+        <EntityDetailRoute phases={{ deploy: DEPLOY_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/deploy/deployments/sentiment-deployment/ongoing-operations',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetDeployment: {
+                deployment: buildDeployment({
+                  status: {
+                    state: DEPLOYMENT_STATE.UNHEALTHY,
+                    stage: DEPLOYMENT_STAGE.ROLLOUT_FAILED,
+                    conditions: [
+                      { type: 'LiveCondition', status: DEPLOYMENT_CONDITION_STATUS.FALSE },
+                    ],
+                    conditionsSnapshot: [],
+                  },
+                }),
+              },
+            }),
+          }),
+        ])
+      );
+
+      await screen.findAllByText('LiveCondition');
+    });
+
+    describe('stages', () => {
+      const page = DEPLOYMENT_DETAIL_CONFIG.pages.find((p) => p.id === 'ongoing-operations') as
+        | ExecutionDetailPageConfig
+        | undefined;
+      const accessor = page?.tasks.accessor as (data: object) => object[];
+      const stateBuilder = page?.tasks.stateBuilder as (
+        record: object,
+        index: number,
+        siblings: object[],
+        data: object
+      ) => string;
+
+      const condition = (status: number) => ({ status });
+      const atStage = (stage: number) => ({ status: { stage } });
+
+      it('marks satisfied conditions as success', () => {
+        const conditions = [condition(DEPLOYMENT_CONDITION_STATUS.TRUE)];
+        expect(
+          stateBuilder(conditions[0], 0, conditions, atStage(DEPLOYMENT_STAGE.PLACEMENT))
+        ).toBe(TASK_STATE.SUCCESS);
+      });
+
+      it('marks the first incomplete condition as running and later ones as pending during an active rollout', () => {
+        const conditions = [
+          condition(DEPLOYMENT_CONDITION_STATUS.TRUE),
+          condition(DEPLOYMENT_CONDITION_STATUS.FALSE),
+          condition(DEPLOYMENT_CONDITION_STATUS.UNKNOWN),
+        ];
+        const data = atStage(DEPLOYMENT_STAGE.PLACEMENT);
+
+        expect(stateBuilder(conditions[1], 1, conditions, data)).toBe(TASK_STATE.RUNNING);
+        expect(stateBuilder(conditions[2], 2, conditions, data)).toBe(TASK_STATE.PENDING);
+      });
+
+      it('treats an unknown-status condition as the running step when it is first incomplete', () => {
+        const conditions = [
+          condition(DEPLOYMENT_CONDITION_STATUS.UNKNOWN),
+          condition(DEPLOYMENT_CONDITION_STATUS.FALSE),
+        ];
+        const data = atStage(DEPLOYMENT_STAGE.VALIDATION);
+
+        expect(stateBuilder(conditions[0], 0, conditions, data)).toBe(TASK_STATE.RUNNING);
+        expect(stateBuilder(conditions[1], 1, conditions, data)).toBe(TASK_STATE.PENDING);
+      });
+
+      it.each([
+        ['rollout failed', DEPLOYMENT_STAGE.ROLLOUT_FAILED],
+        ['rollback failed', DEPLOYMENT_STAGE.ROLLBACK_FAILED],
+      ])('marks the first incomplete condition as error when %s', (_label, stage) => {
+        const conditions = [
+          condition(DEPLOYMENT_CONDITION_STATUS.TRUE),
+          condition(DEPLOYMENT_CONDITION_STATUS.FALSE),
+          condition(DEPLOYMENT_CONDITION_STATUS.UNKNOWN),
+        ];
+        const data = atStage(stage);
+
+        expect(stateBuilder(conditions[1], 1, conditions, data)).toBe(TASK_STATE.ERROR);
+        expect(stateBuilder(conditions[2], 2, conditions, data)).toBe(TASK_STATE.PENDING);
+      });
+
+      it('returns live conditions during an active rollout', () => {
+        const conditions = [{ type: 'Live' }];
+        const conditionsSnapshot = [{ type: 'Snapshot' }];
+        expect(
+          accessor({
+            status: { stage: DEPLOYMENT_STAGE.PLACEMENT, conditions, conditionsSnapshot },
+          })
+        ).toEqual(conditions);
+      });
+
+      it.each([
+        ['rollout failed', DEPLOYMENT_STAGE.ROLLOUT_FAILED],
+        ['rollback failed', DEPLOYMENT_STAGE.ROLLBACK_FAILED],
+      ])('returns the snapshot when %s', (_label, stage) => {
+        const conditions = [{ type: 'Live' }];
+        const conditionsSnapshot = [{ type: 'Snapshot' }];
+        expect(accessor({ status: { stage, conditions, conditionsSnapshot } })).toEqual(
+          conditionsSnapshot
+        );
+      });
+
+      it('falls back to live conditions when the failed-rollout snapshot is empty', () => {
+        const conditions = [{ type: 'Live' }];
+        expect(
+          accessor({
+            status: {
+              stage: DEPLOYMENT_STAGE.ROLLOUT_FAILED,
+              conditions,
+              conditionsSnapshot: [],
+            },
+          })
+        ).toEqual(conditions);
+      });
+
+      it('returns an empty list when status is missing', () => {
+        expect(accessor({})).toEqual([]);
+      });
     });
   });
 });

--- a/javascript/packages/core/config/entities/deployment/detail.ts
+++ b/javascript/packages/core/config/entities/deployment/detail.ts
@@ -1,14 +1,26 @@
 import { CellType } from '#core/components/cell/constants';
+import { TAG_COLOR } from '#core/components/tag/constants';
 import { TASK_STATE } from '#core/components/views/execution/constants';
 import { DeploymentInfoPage } from './deployment-info-page';
 import {
   DEPLOYMENT_CONDITION_STATUS,
-  DEPLOYMENT_STAGE,
   DEPLOYMENT_STAGE_CELL,
   DEPLOYMENT_STATE_CELL,
+  FAILED_ROLLOUT_STAGES,
 } from './shared';
 
 import type { DetailViewConfig } from '#core/components/views/types';
+
+/**
+ * State-cell keys per condition status. CONDITION_STATUS_UNKNOWN is 0, which
+ * the state cell drops as a missing value — map to string keys so every
+ * status renders.
+ */
+const CONDITION_STATUS_KEYS: Record<number, string> = {
+  [DEPLOYMENT_CONDITION_STATUS.TRUE]: 'CONDITION_STATUS_TRUE',
+  [DEPLOYMENT_CONDITION_STATUS.FALSE]: 'CONDITION_STATUS_FALSE',
+  [DEPLOYMENT_CONDITION_STATUS.UNKNOWN]: 'CONDITION_STATUS_UNKNOWN',
+};
 
 export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
   type: 'detail',
@@ -37,10 +49,12 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
         accessor: (data: {
           status?: { stage?: number; conditions?: object[]; conditionsSnapshot?: object[] };
         }) => {
+          const status = data?.status;
+          const hasSnapshot = (status?.conditionsSnapshot?.length ?? 0) > 0;
           const conditions =
-            data?.status?.stage === DEPLOYMENT_STAGE.ROLLOUT_FAILED
-              ? data?.status?.conditionsSnapshot
-              : data?.status?.conditions;
+            isFailedRollout(status?.stage) && hasSnapshot
+              ? status?.conditionsSnapshot
+              : status?.conditions;
           return conditions ?? [];
         },
         header: {
@@ -53,6 +67,24 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
               accessor: (record: { lastUpdatedTimestamp?: string | number | bigint }) => {
                 const ts = record.lastUpdatedTimestamp;
                 return ts ? Math.floor(Number(ts) / 1000) : undefined;
+              },
+            },
+            {
+              id: 'status',
+              label: 'State',
+              type: CellType.STATE,
+              accessor: (record: { status?: number }) =>
+                CONDITION_STATUS_KEYS[record.status ?? DEPLOYMENT_CONDITION_STATUS.UNKNOWN] ??
+                'CONDITION_STATUS_UNKNOWN',
+              stateTextMap: {
+                CONDITION_STATUS_TRUE: 'Succeeded',
+                CONDITION_STATUS_FALSE: 'Running',
+                CONDITION_STATUS_UNKNOWN: 'Pending',
+              },
+              stateColorMap: {
+                CONDITION_STATUS_TRUE: TAG_COLOR.green,
+                CONDITION_STATUS_FALSE: TAG_COLOR.blue,
+                CONDITION_STATUS_UNKNOWN: TAG_COLOR.gray,
               },
             },
           ],
@@ -71,18 +103,30 @@ export const DEPLOYMENT_DETAIL_CONFIG: DetailViewConfig = {
             markdown: false,
           },
         ],
-        stateBuilder: (record: { status: number }) => {
-          switch (record.status) {
-            case DEPLOYMENT_CONDITION_STATUS.TRUE:
-              return TASK_STATE.SUCCESS;
-            case DEPLOYMENT_CONDITION_STATUS.FALSE:
-              return TASK_STATE.ERROR;
-            case DEPLOYMENT_CONDITION_STATUS.UNKNOWN:
-            default:
-              return TASK_STATE.RUNNING;
+        stateBuilder: (
+          record: { status: number },
+          index: number,
+          siblings: { status: number }[],
+          data: { status?: { stage?: number } }
+        ) => {
+          if (record.status === DEPLOYMENT_CONDITION_STATUS.TRUE) return TASK_STATE.SUCCESS;
+
+          // The first incomplete condition is the step the controller is working
+          // on: running while the rollout is healthy, the failure point otherwise.
+          // Conditions behind it haven't been reached yet.
+          const isFirstIncomplete =
+            siblings.findIndex((s) => s.status !== DEPLOYMENT_CONDITION_STATUS.TRUE) === index;
+
+          if (isFirstIncomplete) {
+            return isFailedRollout(data.status?.stage) ? TASK_STATE.ERROR : TASK_STATE.RUNNING;
           }
+          return TASK_STATE.PENDING;
         },
       },
     },
   ],
 };
+
+function isFailedRollout(stage: number | undefined): boolean {
+  return stage != null && FAILED_ROLLOUT_STAGES.includes(stage);
+}

--- a/javascript/packages/core/config/entities/deployment/shared.ts
+++ b/javascript/packages/core/config/entities/deployment/shared.ts
@@ -23,6 +23,12 @@ export const DEPLOYMENT_STAGE = {
   CLEAN_UP_FAILED: 11,
 } as const;
 
+/** Stages in which a FALSE condition marks a real failure rather than "not reached yet". */
+export const FAILED_ROLLOUT_STAGES: number[] = [
+  DEPLOYMENT_STAGE.ROLLOUT_FAILED,
+  DEPLOYMENT_STAGE.ROLLBACK_FAILED,
+];
+
 export const DEPLOYMENT_STATE = {
   INVALID: 0,
   INITIALIZING: 1,


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Previously, we would render pending stages on the Ongoing operations tab for deployments as errors. Now we render all stages after the current stage as pending.


| Before | After | 
| -- | -- | 
| <img width="942" height="809" alt="image" src="https://github.com/user-attachments/assets/2ba2b1bf-f9f2-4c3f-98c3-616b4b3a4753" /> | <img width="943" height="835" alt="image" src="https://github.com/user-attachments/assets/ad46f963-60ad-4cb5-b69a-08bc3ddf4539" /> |


<!-- Tell your future self why have you made these changes -->
**Why?**
The logic for rendering the stages was incorrect. Pending stages shouldn't be seen as errors.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A