### PR TITLE
feat(python): support file-backed task kwargs

### DIFF
--- a/python/michelangelo/uniflow/core/run_task.py
+++ b/python/michelangelo/uniflow/core/run_task.py
@@ -5,6 +5,8 @@ import argparse
 import logging
 import sys
 
+import fsspec
+
 from michelangelo.uniflow.core.codec import decoder
 from michelangelo.uniflow.core.utils import LOGGING_FORMAT, import_attribute
 
@@ -19,16 +21,20 @@ def main():
     p = argparse.ArgumentParser()
     p.add_argument("--task", required=True, type=str)
     p.add_argument("--args", required=True, type=_decode_arg)
-    p.add_argument("--kwargs", required=True, type=_decode_arg)
+    kwargs_group = p.add_mutually_exclusive_group(required=True)
+    kwargs_group.add_argument("--kwargs", type=_decode_arg)
+    kwargs_group.add_argument("--kwargs-file", type=_decode_kwargs_file)
     p.add_argument("--result-url", required=True, type=str)
     p.add_argument("--overrides", type=_decode_arg)
     ns = p.parse_args()
 
+    kwargs = ns.kwargs if ns.kwargs is not None else ns.kwargs_file
+
     assert isinstance(ns.args, list), (
         f"Expected args to be a list, but got {type(ns.args)}"
     )
-    assert isinstance(ns.kwargs, dict), (
-        f"Expected kwargs to be a dict, but got {type(ns.kwargs)}"
+    assert isinstance(kwargs, dict), (
+        f"Expected kwargs to be a dict, but got {type(kwargs)}"
     )
     assert isinstance(ns.result_url, str), (
         f"Expected result_url to be a string, but got {type(ns.result_url)}"
@@ -49,7 +55,7 @@ def main():
 
     task(
         *ns.args,
-        **ns.kwargs,
+        **kwargs,
         _uf_result_url=ns.result_url,
     )
     log.info("[ ok ]")
@@ -68,6 +74,17 @@ def _decode_arg(value: str):
         return decoder.decode(value)
     except Exception as e:
         error_message = f"Failed to decode argument: {value}"
+        log.error(error_message, exc_info=True)
+        raise argparse.ArgumentTypeError(error_message) from e
+
+
+def _decode_kwargs_file(path: str):
+    """Read and decode task keyword arguments from an fsspec URL or path."""
+    try:
+        with fsspec.open(path, mode="rt", encoding="utf-8") as stream:
+            return decoder.decode(stream.read())
+    except Exception as e:
+        error_message = f"Failed to decode kwargs file: {path}"
         log.error(error_message, exc_info=True)
         raise argparse.ArgumentTypeError(error_message) from e
 

--- a/python/tests/uniflow/core/test_run_task.py
+++ b/python/tests/uniflow/core/test_run_task.py
@@ -1,7 +1,14 @@
+"""Tests for the Uniflow task runner entrypoint."""
+
 import json
+import os
+import subprocess
+import sys
+import tempfile
 import unittest
 import uuid
 from dataclasses import dataclass
+from pathlib import Path
 from unittest import mock
 
 import fsspec
@@ -14,7 +21,7 @@ from michelangelo.uniflow.core.utils import dot_path
 
 
 @dataclass
-class TestTaskConfig(TaskConfig):  # noqa: D101
+class RunTaskConfig(TaskConfig):  # noqa: D101
     def pre_run(self):  # noqa: D102
         pass
 
@@ -29,12 +36,22 @@ class TestTaskConfig(TaskConfig):  # noqa: D101
         raise NotImplementedError  # Not called in this test
 
 
-@task(config=TestTaskConfig(), alias="echo")
+@task(config=RunTaskConfig(), alias="echo")
 def echo_task(x) -> dict:  # noqa: D103
     return {
         "input": x,
         "alias": task_context.alias,
     }
+
+
+@task(config=RunTaskConfig(), alias="capture_kwargs")
+def capture_kwargs_task(**kwargs) -> dict:  # noqa: D103
+    return kwargs
+
+
+@task(config=RunTaskConfig(), alias="kwargs_size")
+def kwargs_size_task(payload) -> dict:  # noqa: D103
+    return {"size": len(payload)}
 
 
 class Test(unittest.TestCase):  # noqa: D101
@@ -64,6 +81,145 @@ class Test(unittest.TestCase):  # noqa: D101
             },
             result,
         )
+
+    def test_local_kwargs_file(self):  # noqa: D102
+        result_url = _random_test_result_url()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as kwargs_file:
+            json.dump({"source": "local"}, kwargs_file)
+            kwargs_file.flush()
+
+            test_args = _task_args(
+                capture_kwargs_task,
+                result_url,
+                "--kwargs-file",
+                kwargs_file.name,
+            )
+            with mock.patch("sys.argv", test_args):
+                run_task_main()
+
+        with fsspec.open(result_url) as f:
+            result = json.load(f)
+
+        self.assertEqual({"source": "local"}, result)
+
+    def test_memory_kwargs_file(self):  # noqa: D102
+        kwargs_url = f"memory://{uuid.uuid4()}.json"
+        result_url = _random_test_result_url()
+        with fsspec.open(kwargs_url, mode="wt", encoding="utf-8") as f:
+            json.dump({"source": "memory"}, f)
+
+        test_args = _task_args(
+            capture_kwargs_task,
+            result_url,
+            "--kwargs-file",
+            kwargs_url,
+        )
+        with mock.patch("sys.argv", test_args):
+            run_task_main()
+
+        with fsspec.open(result_url) as f:
+            result = json.load(f)
+
+        self.assertEqual({"source": "memory"}, result)
+
+    def test_kwargs_inputs_are_required_and_mutually_exclusive(self):  # noqa: D102
+        result_url = _random_test_result_url()
+        without_kwargs = [
+            "test",
+            "--task",
+            dot_path(capture_kwargs_task),
+            "--args",
+            "[]",
+            "--result-url",
+            result_url,
+        ]
+        with (
+            mock.patch("sys.argv", without_kwargs),
+            self.assertRaisesRegex(SystemExit, "2"),
+        ):
+            run_task_main()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as kwargs_file:
+            kwargs_file.write("{}")
+            kwargs_file.flush()
+            both_kwargs = [
+                *without_kwargs,
+                "--kwargs",
+                "{}",
+                "--kwargs-file",
+                kwargs_file.name,
+            ]
+            with (
+                mock.patch("sys.argv", both_kwargs),
+                self.assertRaisesRegex(SystemExit, "2"),
+            ):
+                run_task_main()
+
+    def test_kwargs_file_must_decode_to_dict(self):  # noqa: D102
+        result_url = _random_test_result_url()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as kwargs_file:
+            kwargs_file.write("[]")
+            kwargs_file.flush()
+
+            test_args = _task_args(
+                capture_kwargs_task,
+                result_url,
+                "--kwargs-file",
+                kwargs_file.name,
+            )
+            with (
+                mock.patch("sys.argv", test_args),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    "Expected kwargs to be a dict",
+                ),
+            ):
+                run_task_main()
+
+    def test_large_kwargs_file_in_subprocess(self):  # noqa: D102
+        payload = "x" * (256 * 1024)
+        encoded_kwargs = json.dumps({"payload": payload})
+        self.assertGreater(len(encoded_kwargs.encode("utf-8")), 128 * 1024)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            kwargs_path = Path(temp_dir) / "kwargs.json"
+            result_path = Path(temp_dir) / "result.json"
+            kwargs_path.write_text(encoded_kwargs, encoding="utf-8")
+
+            process = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "michelangelo.uniflow.core.run_task",
+                    "--task",
+                    dot_path(kwargs_size_task),
+                    "--args",
+                    "[]",
+                    "--kwargs-file",
+                    str(kwargs_path),
+                    "--result-url",
+                    str(result_path),
+                ],
+                cwd=Path(__file__).parents[3],
+                capture_output=True,
+                check=False,
+                env={
+                    **os.environ,
+                    "PYTHONPATH": os.pathsep.join(
+                        [
+                            str(Path(__file__).parent),
+                            str(Path(__file__).parents[3]),
+                        ]
+                    ),
+                },
+                text=True,
+            )
+
+            self.assertEqual(0, process.returncode, process.stderr)
+            self.assertEqual(
+                {"size": len(payload)},
+                json.loads(result_path.read_text(encoding="utf-8")),
+            )
 
     def test_overrides(self):  # noqa: D102
         result_url = _random_test_result_url()
@@ -113,3 +269,17 @@ class Test(unittest.TestCase):  # noqa: D101
 
 def _random_test_result_url():
     return f"memory://{uuid.uuid4()}.json"
+
+
+def _task_args(task_function, result_url, kwargs_flag, kwargs_value):
+    return [
+        "test",
+        "--task",
+        dot_path(task_function),
+        "--args",
+        "[]",
+        kwargs_flag,
+        kwargs_value,
+        "--result-url",
+        result_url,
+    ]

--- a/python/tests/uniflow/core/test_run_task_decode_arg.py
+++ b/python/tests/uniflow/core/test_run_task_decode_arg.py
@@ -1,10 +1,13 @@
 """Tests for the _decode_arg function in run_task module."""
 
 import argparse
+import json
 import logging
+import tempfile
 import unittest
 
-from michelangelo.uniflow.core.run_task import _decode_arg
+from michelangelo.uniflow.core.codec import encoder
+from michelangelo.uniflow.core.run_task import _decode_arg, _decode_kwargs_file
 
 
 class TestDecodeArg(unittest.TestCase):
@@ -53,3 +56,49 @@ class TestDecodeArg(unittest.TestCase):
         self.assertIn(f"Failed to decode argument: {value}", record.message)
         # Verify exc_info is present (stack trace)
         self.assertIsNotNone(record.exc_info)
+
+
+class TestDecodeKwargsFile(unittest.TestCase):
+    """Tests for _decode_kwargs_file."""
+
+    def test_codec_values_match_inline_decoding(self):
+        """Test that files retain the inline path's custom codec behavior."""
+        encoded = json.dumps(
+            {"payload": b"binary kwargs"},
+            separators=(",", ":"),
+            default=encoder.default,
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as kwargs_file:
+            kwargs_file.write(encoded)
+            kwargs_file.flush()
+
+            from_file = _decode_kwargs_file(kwargs_file.name)
+
+        self.assertEqual(_decode_arg(encoded), from_file)
+
+    def test_missing_file_retains_cause(self):
+        """Test that file read failures retain their underlying exception."""
+        path = "/a/kwargs/file/that/does/not/exist.json"
+
+        with self.assertRaises(argparse.ArgumentTypeError) as cm:
+            _decode_kwargs_file(path)
+
+        self.assertEqual(f"Failed to decode kwargs file: {path}", str(cm.exception))
+        self.assertIsInstance(cm.exception.__cause__, FileNotFoundError)
+
+    def test_malformed_file_retains_cause_without_logging_contents(self):
+        """Test that decode failures retain their cause without leaking contents."""
+        secret_contents = "not-json-sensitive-contents"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json") as kwargs_file:
+            kwargs_file.write(secret_contents)
+            kwargs_file.flush()
+
+            with (
+                self.assertRaises(argparse.ArgumentTypeError) as cm,
+                self.assertLogs(level=logging.ERROR) as logs,
+            ):
+                _decode_kwargs_file(kwargs_file.name)
+
+        self.assertIsInstance(cm.exception.__cause__, json.JSONDecodeError)
+        self.assertIn(kwargs_file.name, logs.output[0])
+        self.assertNotIn(secret_contents, logs.output[0])


### PR DESCRIPTION
## Summary
Intent:
- Avoid process argument-size failures when task kwargs are stored externally.
- Keep the runner contract storage-agnostic through fsspec.

Changes:
- Accept exactly one of --kwargs and --kwargs-file while preserving inline callers.
- Read file-backed kwargs as UTF-8 and decode them with the existing Uniflow codec.
- Cover local and memory filesystems, CLI validation, safe errors, codec parity, and oversized subprocess input.

## Test Plan
- Targeted runner suite: 14 passed.
- Uniflow core suite excluding Docker-dependent file_sync tests: 75 passed.
- Ruff formatting and lint checks passed for every changed Python file.
- Built michelangelo-0.9.0-py3-none-any.whl successfully.
- The full core attempt reached 106 passed and 6 environment-only failures because the borrowed local virtualenv lacks the optional docker package; all failures were in test_file_sync.py.

---

<sub>Generated by the 🪄 [pr-create](https://sg.uberinternal.com/code.uber.internal/uber-code/devexp-agent-marketplace/-/blob/claude-code/plugins/dev/uber-dev/skills/pr-create/SKILL.md) skill in devexp-agent-marketplace</sub>

## Issues

