### PR TITLE
docs(ui): update entity config examples for the Pipeline Runs → Runs rename

### DIFF
--- a/docs/contributing/dev/ui/configuration/configuration-api.md
+++ b/docs/contributing/dev/ui/configuration/configuration-api.md
@@ -46,7 +46,7 @@ See [`javascript/packages/core/config/phases`](https://github.com/michelangelo-a
 // Example: config/entities/run/run.ts
 export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'runs',
-  name: 'Pipeline Runs',
+  name: 'Runs',
   service: 'pipelineRun',
   state: 'active',
   views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],

--- a/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
@@ -33,7 +33,7 @@ The `state` property controls individual entity behavior within a phase:
 // From: config/entities/run/run.ts
 export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'runs',
-  name: 'Pipeline Runs',
+  name: 'Runs',
   service: 'pipelineRun',
   state: 'active',
   views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],
@@ -52,7 +52,7 @@ export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
 ### `name`
 - Display name shown in navigation and headers
 - Recommended: plural, descriptive
-- Examples: `"Pipeline Runs"`, `"Pipelines"`, `"Trained Models"`
+- Examples: `"Runs"`, `"Pipelines"`, `"Trained Models"`
 - Can be intentionally not pluralized for special cases (e.g., `"Feature Consistency"`)
 
 ### `service`
@@ -109,7 +109,7 @@ service PipelineRunService {
 // Entity config
 {
   id: 'runs',
-  name: 'Pipeline Runs',
+  name: 'Runs',
   service: 'pipelineRun', // ← Must match root field name
   // ...
 }


### PR DESCRIPTION
## Summary

PR #1964 renamed `RUN_ENTITY_CONFIG.name` from `'Pipeline Runs'` to `'Runs'`. Two UI configuration docs quote that config verbatim — one of them literally labelled `// From: config/entities/run/run.ts` — and both still show the old value, so the copy-pasteable examples no longer match [the source](https://github.com/michelangelo-ai/michelangelo/blob/main/javascript/packages/core/config/entities/run/run.ts#L82-L88).

**What changed (4 lines, 2 files):**
- `entity-configuration-reference.md` — two `RUN_ENTITY_CONFIG` code blocks, plus the `name` property's examples list, which would otherwise contradict the two code blocks around it
- `configuration-api.md` — one `RUN_ENTITY_CONFIG` code block

**Deliberately not touched:** the `### Pipeline Runs` heading in `docs/operator-guides/operations/monitoring.md`. That section documents the `pipelinerun_*` metrics, which describe the PipelineRun resource rather than the renamed UI tab, and renaming it would break the heading anchor for no gain.

## Context

Found by the `ma-oss-docquality` audit harness. `entity-configuration-reference.md` was also 160 days stale; `configuration-api.md` was inside the freshness window and wrong anyway, which is a decent illustration that mtime and accuracy are separate things.

## Test plan
- [x] `grep -rn "Pipeline Runs" docs/contributing/` returns nothing
- [x] Remaining values match `run.ts` L82–88 exactly
- [ ] docs-check CI (no link changes — text-only edits inside code fences and one bullet)