### PR TITLE
perf: improve mobile page load performance

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -79,8 +79,6 @@ const config: Config = {
       logo: {
         alt: 'Michelangelo Logo',
         src: 'img/logo.svg',
-        width: 204,
-        height: 129,
       },
       items: [
         {

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -17,6 +17,17 @@ const config: Config = {
   organizationName: 'michelangelo-ai',
   projectName: 'michelangelo',
 
+  headTags: [
+    {
+      tagName: 'link',
+      attributes: {
+        rel: 'preconnect',
+        href: 'https://tb-static.uber.com',
+        crossorigin: 'anonymous',
+      },
+    },
+  ],
+
   // In CI lint mode, use 'warn' so all broken links are reported at once
   // rather than failing on the first one. The workflow fails the build after
   // annotating every broken link.
@@ -68,6 +79,8 @@ const config: Config = {
       logo: {
         alt: 'Michelangelo Logo',
         src: 'img/logo.svg',
+        width: 204,
+        height: 129,
       },
       items: [
         {

--- a/website/src/components/Landing/Hero.tsx
+++ b/website/src/components/Landing/Hero.tsx
@@ -14,6 +14,9 @@ export default function Hero(): React.ReactElement {
           className={styles.heroLogo}
           src={logoSrc}
           alt="Michelangelo logo"
+          width={204}
+          height={129}
+          fetchPriority="high"
         />
         <h1 className={styles.heroTitle}>
           The ML Platform Behind Uber&apos;s AI.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -9,29 +9,11 @@
 
 @font-face {
   font-family: 'UberMove';
-  font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff2') format('woff2'),
-    url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff') format('woff');
-}
-
-@font-face {
-  font-family: 'UberMove';
   font-weight: 400;
   font-style: normal;
   font-display: swap;
   src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff2') format('woff2'),
     url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff') format('woff');
-}
-
-@font-face {
-  font-family: 'UberMove';
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff2') format('woff2'),
-    url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff') format('woff');
 }
 
 @font-face {
@@ -45,29 +27,11 @@
 
 @font-face {
   font-family: 'UberMoveText';
-  font-weight: 300;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff2') format('woff2'),
-    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff') format('woff');
-}
-
-@font-face {
-  font-family: 'UberMoveText';
   font-weight: 400;
   font-style: normal;
   font-display: swap;
   src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff2') format('woff2'),
     url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff') format('woff');
-}
-
-@font-face {
-  font-family: 'UberMoveText';
-  font-weight: 500;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff2') format('woff2'),
-    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff') format('woff');
 }
 
 @font-face {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -9,11 +9,29 @@
 
 @font-face {
   font-family: 'UberMove';
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Light.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMove';
   font-weight: 400;
   font-style: normal;
   font-display: swap;
   src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff2') format('woff2'),
     url('https://tb-static.uber.com/prod/uber-static/UberMove-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMove';
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMove-Medium.woff') format('woff');
 }
 
 @font-face {
@@ -27,11 +45,29 @@
 
 @font-face {
   font-family: 'UberMoveText';
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Light.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
   font-weight: 400;
   font-style: normal;
   font-display: swap;
   src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff2') format('woff2'),
     url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Regular.woff') format('woff');
+}
+
+@font-face {
+  font-family: 'UberMoveText';
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+  src: url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff2') format('woff2'),
+    url('https://tb-static.uber.com/prod/uber-static/UberMoveText-Medium.woff') format('woff');
 }
 
 @font-face {

--- a/website/src/css/landing.module.css
+++ b/website/src/css/landing.module.css
@@ -19,7 +19,7 @@
   font-weight: 600;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.4);
+  color: rgba(255, 255, 255, 0.55);
   margin: 0 0 36px;
 }
 


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

**What changed?**

- Added an early connection hint for the existing Uber font host without changing the font-face set.
- Added matching intrinsic dimensions and high fetch priority to the responsive hero logo.
- Increased the landing-page statistics heading contrast to meet WCAG AA.

**Why?**

The mobile PageSpeed report showed delayed first and largest contentful paint from the cross-origin font connection and a low-priority, unsized LCP image. It also identified a contrast failure in the statistics section.

**How did you test it?**

- Ran `bun install --frozen-lockfile` with Bun 1.3.14.
- Ran `bun run typecheck`, `bun run build`, and `git diff --check`.
- Verified generated output contains the font preconnect and high-priority 204x129 hero image.
- Compared home, docs, blog, navigation, and typography at mobile and desktop sizes; all existing 300/400/500/700 font faces remain unchanged.

**Potential risks**

Low. The hero dimensions match the SVG aspect ratio and CSS continues to control its responsive rendered size. The statistics heading contrast increase is the only intentional visual change.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

N/A
