### PR TITLE
docs(architecture): reject client-side filtering of option lists

### DIFF
--- a/javascript/packages/core/ARCHITECTURE.md
+++ b/javascript/packages/core/ARCHITECTURE.md
@@ -56,6 +56,10 @@ Configurations are not a flat catalog. They compose:
 
 An action's mutation payload is the record itself — the current row or page entity, optionally reshaped by `middleware`. Whether a request needs shaping is controlled by how an operator configures `ServiceProvider.request`.
 
+### Filtering option lists
+
+A dropdown or select field whose options come from a list query (a `pipeline` picker, a `revision` picker, and similar) **must** narrow that query server-side via `listOptions`/`listOptionsExt` — passed through the query's `serviceOptions`, as in `resume-run-fields.tsx`'s `buildPipelineRunFilter` or `model-family-revision-fields.tsx`'s `modelFamilyListOptionsExt`. Fetching the full list and filtering it in JS is not an accepted alternative, even for a component that only ever renders a handful of options: it pulls in rows the field will never show, moves filtering logic away from the data source and into the field, and stops scaling the moment the backing collection grows past what one page of results can hold. If the field's filter criterion isn't expressible as a `listOptions`/`listOptionsExt` filter, that's a query-layer gap to close, not a reason to filter client-side.
+
 ### Customization escape hatches
 
 The configuration runtime is the path of least resistance. Most customization happens by adjusting configuration — registering custom column renderers, choosing different field types, supplying disabled rules. Specific escape hatches let consumers ship React components when an interaction doesn't fit configuration:


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Documentation Update

**What changed?**

Adds a "Filtering option lists" subsection to `javascript/packages/core/ARCHITECTURE.md` under §3 Configuration System. It requires dropdown/select fields whose options come from a list query to narrow that query server-side via `listOptions`/`listOptionsExt`, and explicitly rejects fetching the full list and filtering it in JS — even for fields that only ever render a handful of options.

**Why?**

A batch review of design-interview-generated PRs found multiple dropdown fields filtering fetched option lists in JS instead of pushing the filter into the query. Client-side filtering pulls in rows the field will never show, moves filtering logic away from the data source and into the field, and stops scaling once the backing collection grows past a page of results. Documenting the server-side-only rule closes this loophole so it's caught during design review rather than in code review.

**How did you test it?**

Read-only documentation change; verified the cited in-repo examples (`resume-run-fields.tsx`'s `buildPipelineRunFilter`, `model-family-revision-fields.tsx`'s `modelFamilyListOptionsExt`) exist and match the pattern being required.

**Potential risks**

None — documentation only, no code changes.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

N/A

**Documentation Changes**

Adds new architectural guidance to `javascript/packages/core/ARCHITECTURE.md`.