### PR TITLE
fix(javascript): audit placeholder text for accessibility and UX guidelines

### DIFF
--- a/javascript/CLAUDE.md
+++ b/javascript/CLAUDE.md
@@ -38,6 +38,7 @@ yarn test
 
 - Start with `useStyletron`; extract to `styled()` at 4+ CSS properties or when used in 2+ places
 - Styled component names are semantic — never `Container`, `Card`, `Wrapper`
+- Placeholder text shows examples, never instructions: prefix with "e.g." and never use action verbs ("Enter…", "Type…", "Select…"); never echo the field's label; default to no placeholder at all unless a concrete example genuinely helps
 
 ### Testing
 

--- a/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
+++ b/javascript/packages/core/components/cell/renderers/retry/retry-cell.tsx
@@ -143,7 +143,7 @@ export const RetryCell = (props: CellRendererProps<string>) => {
         <Textarea
           value={retryReason}
           onChange={(e) => setRetryReason(e.target.value)}
-          placeholder="Enter reason for retry..."
+          placeholder="e.g. Fixed the input schema mismatch"
           overrides={{
             Input: {
               style: {

--- a/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
+++ b/javascript/packages/core/components/form/__tests__/config-driven-form.test.tsx
@@ -96,7 +96,8 @@ describe('ConfigDrivenForm', () => {
       const user = userEvent.setup();
       await user.click(screen.getByRole('button', { name: 'Add more' }));
 
-      expect(screen.getAllByRole('textbox', { name: '' }).length).toBeGreaterThanOrEqual(2);
+      expect(screen.getAllByRole('textbox', { name: 'Key' }).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByRole('textbox', { name: 'Value' }).length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders a markdown field', () => {

--- a/javascript/packages/core/components/form/fields/map/key-value-row.tsx
+++ b/javascript/packages/core/components/form/fields/map/key-value-row.tsx
@@ -51,6 +51,7 @@ export function KeyValueRow({
         onFocus={onFocus}
         onBlur={handleBlurIfFilled}
         placeholder={keyConfig?.placeholder ?? 'Key'}
+        aria-label={keyConfig?.placeholder ?? 'Key'}
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- false is a valid value, so || is needed to fall through to keyConfig?.readOnly
         readOnly={readOnly || keyConfig?.readOnly}
         disabled={disabled}
@@ -69,6 +70,7 @@ export function KeyValueRow({
         onFocus={onFocus}
         onBlur={handleBlurIfFilled}
         placeholder={valueConfig?.placeholder ?? 'Value'}
+        aria-label={valueConfig?.placeholder ?? 'Value'}
         readOnly={readOnly}
         disabled={disabled}
         size={size}

--- a/javascript/packages/core/components/form/fields/map/types.ts
+++ b/javascript/packages/core/components/form/fields/map/types.ts
@@ -10,10 +10,20 @@ export interface KeyValueEntry {
 
 /** Props shared between MapField and KeyValueRow — controls how each row renders. */
 export interface KeyValueRowConfig {
-  /** Configuration for the key input column */
+  /**
+   * Configuration for the key input column.
+   *
+   * `placeholder` doubles as the column's accessible name, since individual rows have no visible
+   * label — see {@link BaseFieldProps.placeholder} for the general placeholder guidance.
+   */
   keyConfig?: { placeholder?: string; readOnly?: boolean };
 
-  /** Configuration for the value input column */
+  /**
+   * Configuration for the value input column.
+   *
+   * `placeholder` doubles as the column's accessible name, since individual rows have no visible
+   * label — see {@link BaseFieldProps.placeholder} for the general placeholder guidance.
+   */
   valueConfig?: { placeholder?: string };
 
   /** Show delete button per row. Defaults to true. */

--- a/javascript/packages/core/components/form/fields/types.ts
+++ b/javascript/packages/core/components/form/fields/types.ts
@@ -47,8 +47,15 @@ export interface BaseFieldProps<T = unknown, InputValue = T> {
   disabled?: boolean;
 
   /**
-   * Specifies a short hint that describes the expected value of the field
-   * **Placeholder text disappears after input is provided.**
+   * Example text shown when the field is empty. **Disappears once input is provided.**
+   *
+   * - Prefix with "e.g." — show an example, not an instruction (`"e.g. my-pipeline"`, not `"Enter pipeline name"`).
+   * - Never echo the field's `label`.
+   * - Never use action verbs ("Enter…", "Type…", "Select…", "Choose…").
+   * - Omit entirely when the label is self-explanatory — not every field needs one.
+   *
+   * See {@link https://www.nngroup.com/articles/form-design-placeholders/} and
+   * {@link https://www.w3.org/WAI/tutorials/forms/instructions/}.
    */
   placeholder?: string;
 

--- a/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
+++ b/javascript/packages/core/components/table/components/table-action-bar/components/table-search-input/table-search-input.tsx
@@ -37,7 +37,7 @@ export function TableSearchInput({ value, onChange }: TableSearchInputProps) {
       overrides={{
         Root: { style: { width: '250px' } },
       }}
-      placeholder="Search..."
+      aria-label="Search"
       startEnhancer={<Icon name="search" />}
     />
   );

--- a/javascript/packages/core/config/entities/deployment/create-deployment-form.tsx
+++ b/javascript/packages/core/config/entities/deployment/create-deployment-form.tsx
@@ -87,7 +87,7 @@ export const CreateDeploymentForm = ({ onClose }: CreateActionComponentProps) =>
           regex(K8S_NAME_PATTERN, K8S_NAME_RULES_MESSAGE)
         )}
         caption={K8S_NAME_RULES_MESSAGE}
-        placeholder="my-deployment"
+        placeholder="e.g. my-deployment"
       />
 
       <SelectField

--- a/javascript/packages/core/config/entities/deployment/model-family-revision-fields.tsx
+++ b/javascript/packages/core/config/entities/deployment/model-family-revision-fields.tsx
@@ -83,7 +83,6 @@ export const ModelFamilyRevisionFields = () => {
         isLoading={isModelLoading}
         disabled={!modelFamilyName}
         clearable={false}
-        placeholder="Search model to deploy"
       />
     </FormGroup>
   );

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -147,7 +147,7 @@ describe('CreatePipelineRunForm', () => {
       })
     );
     await user.type(
-      within(dialog).getByPlaceholderText('e.g., name@example.com'),
+      within(dialog).getByPlaceholderText('e.g. name@example.com'),
       'oncall@example.com'
     );
     await selectEnvironment(user, dialog, 'Development');
@@ -204,10 +204,10 @@ describe('CreatePipelineRunForm', () => {
       })
     );
     await user.type(
-      within(dialog).getByPlaceholderText('e.g., name@example.com'),
+      within(dialog).getByPlaceholderText('e.g. name@example.com'),
       'oncall@example.com'
     );
-    await user.type(within(dialog).getByPlaceholderText('e.g., #channel or @user'), '#ml-oncall');
+    await user.type(within(dialog).getByPlaceholderText('e.g. #channel or @user'), '#ml-oncall');
     await selectEnvironment(user, dialog, 'Development');
     await user.click(within(dialog).getByRole('button', { name: 'Run' }));
 

--- a/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/create-pipeline-run-form.tsx
@@ -95,7 +95,6 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
       <TextareaField
         name="spec.description"
         label="Description"
-        placeholder="Enter a description for this run…"
         description="Optional. Helps identify this run in the pipeline run list."
       />
 
@@ -117,14 +116,14 @@ export const CreatePipelineRunForm = ({ record, onClose }: ActionComponentProps<
                   label="Emails"
                   multi
                   validate={validateEmails}
-                  placeholder="e.g., name@example.com"
+                  placeholder="e.g. name@example.com"
                 />
 
                 <StringField
                   name="notificationSlackDestinations"
                   label="Slack Channels or Users"
                   multi
-                  placeholder="e.g., #channel or @user"
+                  placeholder="e.g. #channel or @user"
                 />
               </>
             ) : null

--- a/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
+++ b/javascript/packages/core/config/entities/pipeline/resume-run-fields.tsx
@@ -111,6 +111,14 @@ export const ResumeRunFields = ({ pipelineName }: { pipelineName: string }) => {
   const hasSourceRun = !!sourceRunName;
   const hasNoSteps = hasSourceRun && !isLoadingSteps && steps.length === 0;
 
+  let stepsCaption =
+    'Leave empty to continue from where the source run stopped, reusing all cached outputs.';
+  if (!hasSourceRun) {
+    stepsCaption = 'Choose a pipeline run above first.';
+  } else if (hasNoSteps) {
+    stepsCaption = 'This run has no recorded workflow tasks to resume from.';
+  }
+
   return (
     <FormGroup
       collapsible
@@ -121,7 +129,6 @@ export const ResumeRunFields = ({ pipelineName }: { pipelineName: string }) => {
       <SelectField
         name={SOURCE_RUN_FIELD}
         label="Pipeline run"
-        placeholder="Search runs…"
         options={sourceRunOptions}
         isLoading={isLoadingRuns}
         caption={
@@ -135,17 +142,12 @@ export const ResumeRunFields = ({ pipelineName }: { pipelineName: string }) => {
         multi
         name={RESUME_FROM_FIELD}
         label="Steps"
-        placeholder={hasSourceRun ? 'Search steps…' : 'Select a pipeline run first'}
         options={stepOptions}
         isLoading={isLoadingSteps}
         disabled={!hasSourceRun || hasNoSteps}
         creatable={false}
         getOptionContent={(option) => <ResumeStepOption step={stepsById.get(option.id)} />}
-        caption={
-          hasNoSteps
-            ? 'This run has no recorded workflow tasks to resume from.'
-            : 'Leave empty to continue from where the source run stopped, reusing all cached outputs.'
-        }
+        caption={stepsCaption}
       />
     </FormGroup>
   );

--- a/javascript/packages/core/config/entities/pipeline/run-trigger-form.tsx
+++ b/javascript/packages/core/config/entities/pipeline/run-trigger-form.tsx
@@ -91,7 +91,6 @@ export const RunTriggerForm = ({ record, onClose }: ActionComponentProps<Pipelin
       <SelectField
         name="sourceTriggerName"
         label="Trigger"
-        placeholder="Select a trigger…"
         options={triggerOptions}
         isLoading={isLoading}
         required

--- a/javascript/packages/core/config/entities/targets/create-inference-server-form.tsx
+++ b/javascript/packages/core/config/entities/targets/create-inference-server-form.tsx
@@ -82,7 +82,7 @@ export const CreateInferenceServerForm = ({ onClose }: CreateActionComponentProp
           regex(K8S_NAME_PATTERN, K8S_NAME_RULES_MESSAGE)
         )}
         caption={K8S_NAME_RULES_MESSAGE}
-        placeholder="e.g., my-inference-server"
+        placeholder="e.g. my-inference-server"
       />
 
       <StringField


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

Audits every form placeholder in `packages/core` against the "e.g." pattern:

- Rewrote placeholders that used action verbs or instructions ("Enter reason for retry...", "Select a trigger...", "Search runs...") into concrete "e.g." examples, or removed them where a caption already carries that guidance.
- Normalized the remaining "e.g.," instances to "e.g." for consistent comma style.
- Added `aria-label` to `TableSearchInput` and the map field's key/value inputs, which relied on placeholder text as their only accessible name.
- Documented the rule on `BaseFieldProps.placeholder` and `KeyValueRowConfig`, with links to the NN/g and W3C guidance behind it.
- Added the same guidance to `javascript/CLAUDE.md` so new fields follow it.

**Why?**

Placeholder text that reads as an instruction ("Enter...", "Select...") duplicates the field's label instead of showing what a valid value looks like, and disappears the moment the user starts typing — the opposite of what a hint is for. A few fields also used placeholder as their only accessible name, which screen readers lose once the field has a value. See [Placeholders in Form Fields Are Harmful](https://www.nngroup.com/articles/form-design-placeholders/) and the [W3C WAI instructions tutorial](https://www.w3.org/WAI/tutorials/forms/instructions/).

**How did you test it?**

I ran the affected unit tests (`config-driven-form.test.tsx`, `create-pipeline-run-form.test.tsx`) after updating their placeholder-text and accessible-name assertions, and ran `yarn typecheck` and `yarn lint` across `packages/core`.

**Potential risks**

Low — text-only and `aria-label` changes to existing form fields. `TableSearchInput` and the map field's key/value inputs now expose an accessible name where they previously had none, which is additive and shouldn't affect existing behavior or styling.

**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

**Release notes**

N/A

**Documentation Changes**

Adds placeholder guidance to `javascript/CLAUDE.md` and JSDoc on `BaseFieldProps.placeholder` / `KeyValueRowConfig`.