### PR TITLE
fix(core): title-case entity names in remaining nav consumers

### DIFF
--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -10,6 +10,7 @@ import { CircleExclamationMarkKind } from '#core/components/illustrations/circle
 import { PageHeader } from '#core/components/page-header/page-header';
 import { Signpost } from '#core/components/signpost/signpost';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
+import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
 import { EntityTable } from './entity-table';
 
 import type { Theme } from 'baseui/theme';
@@ -113,7 +114,7 @@ export function PhaseEntityView<T extends object = object>({
         }}
       >
         {entities.map((entity, index) => (
-          <Tab key={String(index)} title={entity.name}>
+          <Tab key={String(index)} title={formatEntityName(entity.name, 'nav')}>
             {String(index) === activeKey && (
               <EntityTable<T>
                 service={entity.service}

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -1,3 +1,12 @@
+// Tab titles need their own small component so `useEntityName` can read the
+// per-title `nav` `DisplayProvider` below as a proper descendant, rather than
+// a hook call sharing PhaseEntityView's own render (which can't loop once per
+// entity anyway). The `nav` override is scoped to just the title node — not
+// the whole tab, and not the whole `Tabs` block — because `EntityTable`
+// renders as a tab's *content*, which sits under the app's ambient `content`
+// region (see `index.tsx`) and must not inherit `nav` casing from a sibling
+// concern.
+/* eslint-disable react/no-multi-comp */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
@@ -10,11 +19,16 @@ import { CircleExclamationMarkKind } from '#core/components/illustrations/circle
 import { PageHeader } from '#core/components/page-header/page-header';
 import { Signpost } from '#core/components/signpost/signpost';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { useEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { DisplayProvider } from '#core/providers/display-provider/display-provider';
 import { EntityTable } from './entity-table';
 
 import type { Theme } from 'baseui/theme';
 import type { PhaseEntityViewProps } from './types';
+
+function EntityTabTitle({ name }: { name: string }) {
+  return <>{useEntityName(name)}</>;
+}
 
 /**
  * Renders tabbed interface for phase entities with URL-synchronized navigation.
@@ -114,7 +128,14 @@ export function PhaseEntityView<T extends object = object>({
         }}
       >
         {entities.map((entity, index) => (
-          <Tab key={String(index)} title={formatEntityName(entity.name, 'nav')}>
+          <Tab
+            key={String(index)}
+            title={
+              <DisplayProvider type="nav">
+                <EntityTabTitle name={entity.name} />
+              </DisplayProvider>
+            }
+          >
             {String(index) === activeKey && (
               <EntityTable<T>
                 service={entity.service}

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -1,12 +1,3 @@
-// Tab titles need their own small component so `useEntityName` can read the
-// per-title `nav` `DisplayProvider` below as a proper descendant, rather than
-// a hook call sharing PhaseEntityView's own render (which can't loop once per
-// entity anyway). The `nav` override is scoped to just the title node — not
-// the whole tab, and not the whole `Tabs` block — because `EntityTable`
-// renders as a tab's *content*, which sits under the app's ambient `content`
-// region (see `index.tsx`) and must not inherit `nav` casing from a sibling
-// concern.
-/* eslint-disable react/no-multi-comp */
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
@@ -19,16 +10,11 @@ import { CircleExclamationMarkKind } from '#core/components/illustrations/circle
 import { PageHeader } from '#core/components/page-header/page-header';
 import { Signpost } from '#core/components/signpost/signpost';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { useEntityName } from '#core/hooks/use-entity-name/use-entity-name';
-import { DisplayProvider } from '#core/providers/display-provider/display-provider';
+import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
 import { EntityTable } from './entity-table';
 
 import type { Theme } from 'baseui/theme';
 import type { PhaseEntityViewProps } from './types';
-
-function EntityTabTitle({ name }: { name: string }) {
-  return <>{useEntityName(name)}</>;
-}
 
 /**
  * Renders tabbed interface for phase entities with URL-synchronized navigation.
@@ -128,14 +114,7 @@ export function PhaseEntityView<T extends object = object>({
         }}
       >
         {entities.map((entity, index) => (
-          <Tab
-            key={String(index)}
-            title={
-              <DisplayProvider type="nav">
-                <EntityTabTitle name={entity.name} />
-              </DisplayProvider>
-            }
-          >
+          <Tab key={String(index)} title={formatEntityName(entity.name, 'nav')}>
             {String(index) === activeKey && (
               <EntityTable<T>
                 service={entity.service}

--- a/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
+++ b/javascript/packages/core/components/views/phase-entity-view/phase-entity-view.tsx
@@ -10,7 +10,7 @@ import { CircleExclamationMarkKind } from '#core/components/illustrations/circle
 import { PageHeader } from '#core/components/page-header/page-header';
 import { Signpost } from '#core/components/signpost/signpost';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
-import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { formatEntityName } from '#core/utils/string-utils';
 import { EntityTable } from './entity-table';
 
 import type { Theme } from 'baseui/theme';

--- a/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
+++ b/javascript/packages/core/components/views/project/__tests__/project-detail.test.tsx
@@ -201,7 +201,7 @@ describe('ProjectDetail', () => {
     expect(screen.getByText('Train & Evaluate')).toBeInTheDocument();
     expect(screen.getByText('Deploy & Predict')).toBeInTheDocument();
 
-    expect(screen.getByRole('link', { name: 'pipelines' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Pipelines' })).toHaveAttribute(
       'href',
       '/fraud-detection/train/pipelines'
     );
@@ -244,13 +244,13 @@ describe('ProjectDetail', () => {
 
     await screen.findByText('Prepare & Analyze Data');
 
-    expect(screen.getByText('pipelines')).toBeInTheDocument();
-    expect(screen.getByText('pipeline runs')).toBeInTheDocument();
-    expect(screen.getByText('data sources')).toBeInTheDocument();
+    expect(screen.getByText('Pipelines')).toBeInTheDocument();
+    expect(screen.getByText('Pipeline Runs')).toBeInTheDocument();
+    expect(screen.getByText('Data Sources')).toBeInTheDocument();
 
-    expect(screen.queryByRole('link', { name: 'pipelines' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'pipeline runs' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'data sources' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Pipelines' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Pipeline Runs' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Data Sources' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
@@ -287,8 +287,8 @@ describe('ProjectDetail', () => {
     await screen.findByText('Deploy & Predict');
 
     expect(screen.getByText('Coming soon')).toBeInTheDocument();
-    expect(screen.getByText('endpoints')).toBeInTheDocument();
-    expect(screen.queryByRole('link', { name: 'endpoints' })).not.toBeInTheDocument();
+    expect(screen.getByText('Endpoints')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Endpoints' })).not.toBeInTheDocument();
   });
 
   test('phase description and learn more button render when docUrl is set', async () => {
@@ -364,10 +364,10 @@ describe('ProjectDetail', () => {
       );
 
       const links: [string, string][] = [
-        ['pipelines', '/fraud-detection/train/pipelines'],
-        ['pipeline runs', '/fraud-detection/train/runs'],
-        ['triggers', '/fraud-detection/train/triggers'],
-        ['trained models', '/fraud-detection/train/models'],
+        ['Pipelines', '/fraud-detection/train/pipelines'],
+        ['Pipeline Runs', '/fraud-detection/train/runs'],
+        ['Triggers', '/fraud-detection/train/triggers'],
+        ['Trained Models', '/fraud-detection/train/models'],
       ];
 
       for (const [name, href] of links) {
@@ -375,10 +375,10 @@ describe('ProjectDetail', () => {
         expect(link).toHaveAttribute('href', href);
       }
 
-      expect(screen.getByText('evaluations')).toBeInTheDocument();
-      expect(screen.getByText('notebooks')).toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'evaluations' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'notebooks' })).not.toBeInTheDocument();
+      expect(screen.getByText('Evaluations')).toBeInTheDocument();
+      expect(screen.getByText('Notebooks')).toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Evaluations' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Notebooks' })).not.toBeInTheDocument();
     });
 
     test('navigate button goes to first active entity', async () => {

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -1,8 +1,9 @@
-// Entity labels need their own small component so `useEntityName` can be
-// called once per entity — PhaseCard's own render can't loop a hook call
-// once per `.map()` iteration. No local `DisplayProvider` is needed here:
-// this card renders in the app's ambient `content` region (see `index.tsx`),
-// which is exactly the casing these labels want.
+// Entity labels need their own small component so `useEntityName` can read
+// the `nav` `DisplayProvider` declared below as a proper descendant, rather
+// than a hook call sharing PhaseCard's own render (which sits above that
+// provider in the tree, and can't loop once per entity anyway). These are
+// clickable links that navigate to an entity — wayfinding chrome, not prose
+// — so they override the app's ambient `content` default back to `nav`.
 /* eslint-disable react/no-multi-comp */
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
@@ -14,6 +15,7 @@ import { Link } from '#core/components/link/link';
 import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
 import { useEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { DisplayProvider } from '#core/providers/display-provider/display-provider';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
@@ -66,36 +68,38 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
         )
       }
     >
-      <div className={css({ display: 'flex', flexDirection: 'column' })}>
-        {entities.map((entity) => {
-          const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
+      <DisplayProvider type="nav">
+        <div className={css({ display: 'flex', flexDirection: 'column' })}>
+          {entities.map((entity) => {
+            const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
 
-          if (isEntityDisabled) {
+            if (isEntityDisabled) {
+              return (
+                <span
+                  key={entity.id}
+                  className={css({
+                    ...theme.typography.ParagraphSmall,
+                    cursor: 'default',
+                    color: theme.colors.contentTertiary,
+                  })}
+                >
+                  <EntityLabel name={entity.name} />
+                </span>
+              );
+            }
+
             return (
-              <span
+              <Link
                 key={entity.id}
-                className={css({
-                  ...theme.typography.ParagraphSmall,
-                  cursor: 'default',
-                  color: theme.colors.contentTertiary,
-                })}
+                href={`/${projectId}/${id}/${entity.id}`}
+                overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
               >
                 <EntityLabel name={entity.name} />
-              </span>
+              </Link>
             );
-          }
-
-          return (
-            <Link
-              key={entity.id}
-              href={`/${projectId}/${id}/${entity.id}`}
-              overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
-            >
-              <EntityLabel name={entity.name} />
-            </Link>
-          );
-        })}
-      </div>
+          })}
+        </div>
+      </DisplayProvider>
 
       {entities.some((entity) => entity.state === 'active') && !isPhaseDisabled && (
         <Button

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -7,6 +7,7 @@ import { Icon } from '#core/components/icon/icon';
 import { Link } from '#core/components/link/link';
 import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
+import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 
@@ -69,7 +70,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
                   color: theme.colors.contentTertiary,
                 })}
               >
-                {entity.name}
+                {formatEntityName(entity.name, 'content')}
               </span>
             );
           }
@@ -80,7 +81,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
               href={`/${projectId}/${id}/${entity.id}`}
               overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
             >
-              {entity.name}
+              {formatEntityName(entity.name, 'content')}
             </Link>
           );
         })}

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -1,10 +1,3 @@
-// Entity labels need their own small component so `useEntityName` can read
-// the `nav` `DisplayProvider` declared below as a proper descendant, rather
-// than a hook call sharing PhaseCard's own render (which sits above that
-// provider in the tree, and can't loop once per entity anyway). These are
-// clickable links that navigate to an entity — wayfinding chrome, not prose
-// — so they override the app's ambient `content` default back to `nav`.
-/* eslint-disable react/no-multi-comp */
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
@@ -14,14 +7,9 @@ import { Icon } from '#core/components/icon/icon';
 import { Link } from '#core/components/link/link';
 import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
-import { useEntityName } from '#core/hooks/use-entity-name/use-entity-name';
-import { DisplayProvider } from '#core/providers/display-provider/display-provider';
+import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
-
-function EntityLabel({ name }: { name: string }) {
-  return <>{useEntityName(name)}</>;
-}
 
 export function PhaseCard(props: PhaseConfig & { projectId: string }) {
   const { id, icon, name, description, docUrl, state, entities, projectId } = props;
@@ -68,38 +56,38 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
         )
       }
     >
-      <DisplayProvider type="nav">
-        <div className={css({ display: 'flex', flexDirection: 'column' })}>
-          {entities.map((entity) => {
-            const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
+      {/* Entity names here are clickable links that navigate to an entity —
+          wayfinding chrome, not prose — so they get `nav` (Title Case). */}
+      <div className={css({ display: 'flex', flexDirection: 'column' })}>
+        {entities.map((entity) => {
+          const isEntityDisabled = isPhaseDisabled || entity.state === 'disabled';
 
-            if (isEntityDisabled) {
-              return (
-                <span
-                  key={entity.id}
-                  className={css({
-                    ...theme.typography.ParagraphSmall,
-                    cursor: 'default',
-                    color: theme.colors.contentTertiary,
-                  })}
-                >
-                  <EntityLabel name={entity.name} />
-                </span>
-              );
-            }
-
+          if (isEntityDisabled) {
             return (
-              <Link
+              <span
                 key={entity.id}
-                href={`/${projectId}/${id}/${entity.id}`}
-                overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
+                className={css({
+                  ...theme.typography.ParagraphSmall,
+                  cursor: 'default',
+                  color: theme.colors.contentTertiary,
+                })}
               >
-                <EntityLabel name={entity.name} />
-              </Link>
+                {formatEntityName(entity.name, 'nav')}
+              </span>
             );
-          })}
-        </div>
-      </DisplayProvider>
+          }
+
+          return (
+            <Link
+              key={entity.id}
+              href={`/${projectId}/${id}/${entity.id}`}
+              overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
+            >
+              {formatEntityName(entity.name, 'nav')}
+            </Link>
+          );
+        })}
+      </div>
 
       {entities.some((entity) => entity.state === 'active') && !isPhaseDisabled && (
         <Button

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -1,3 +1,9 @@
+// Entity labels need their own small component so `useEntityName` can be
+// called once per entity — PhaseCard's own render can't loop a hook call
+// once per `.map()` iteration. No local `DisplayProvider` is needed here:
+// this card renders in the app's ambient `content` region (see `index.tsx`),
+// which is exactly the casing these labels want.
+/* eslint-disable react/no-multi-comp */
 import { useNavigate } from 'react-router-dom-v5-compat';
 import { useStyletron } from 'baseui';
 import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
@@ -7,9 +13,13 @@ import { Icon } from '#core/components/icon/icon';
 import { Link } from '#core/components/link/link';
 import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
-import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { useEntityName } from '#core/hooks/use-entity-name/use-entity-name';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
+
+function EntityLabel({ name }: { name: string }) {
+  return <>{useEntityName(name)}</>;
+}
 
 export function PhaseCard(props: PhaseConfig & { projectId: string }) {
   const { id, icon, name, description, docUrl, state, entities, projectId } = props;
@@ -70,7 +80,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
                   color: theme.colors.contentTertiary,
                 })}
               >
-                {formatEntityName(entity.name, 'content')}
+                <EntityLabel name={entity.name} />
               </span>
             );
           }
@@ -81,7 +91,7 @@ export function PhaseCard(props: PhaseConfig & { projectId: string }) {
               href={`/${projectId}/${id}/${entity.id}`}
               overrides={{ Link: { style: theme.typography.ParagraphSmall } }}
             >
-              {formatEntityName(entity.name, 'content')}
+              <EntityLabel name={entity.name} />
             </Link>
           );
         })}

--- a/javascript/packages/core/components/views/project/components/phase-card.tsx
+++ b/javascript/packages/core/components/views/project/components/phase-card.tsx
@@ -7,7 +7,7 @@ import { Icon } from '#core/components/icon/icon';
 import { Link } from '#core/components/link/link';
 import { TAG_COLOR, TAG_SIZE } from '#core/components/tag/constants';
 import { Tag } from '#core/components/tag/tag';
-import { formatEntityName } from '#core/hooks/use-entity-name/use-entity-name';
+import { formatEntityName } from '#core/utils/string-utils';
 
 import type { PhaseConfig } from '#core/types/common/studio-types';
 

--- a/javascript/packages/core/config/entities/deployment/deployment.ts
+++ b/javascript/packages/core/config/entities/deployment/deployment.ts
@@ -6,7 +6,7 @@ import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
 export const DEPLOYMENT_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'deployments',
-  name: 'Deployments',
+  name: 'deployments',
   service: 'deployment',
   state: 'active',
   views: [DEPLOYMENT_LIST_CONFIG, DEPLOYMENT_DETAIL_CONFIG],

--- a/javascript/packages/core/config/entities/model/model.ts
+++ b/javascript/packages/core/config/entities/model/model.ts
@@ -5,7 +5,7 @@ import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
 export const MODEL_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'models',
-  name: 'Trained Models',
+  name: 'trained models',
   service: 'model',
   state: 'active',
   views: [MODEL_LIST_CONFIG, MODEL_DETAIL_CONFIG],

--- a/javascript/packages/core/config/entities/pipeline/pipeline.ts
+++ b/javascript/packages/core/config/entities/pipeline/pipeline.ts
@@ -21,7 +21,7 @@ const hasNoTriggers = (record: unknown): boolean => {
 
 export const PIPELINE_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'pipelines',
-  name: 'Pipelines',
+  name: 'pipelines',
   service: 'pipeline',
   state: 'active',
   views: [PIPELINE_LIST_CONFIG, PIPELINE_DETAIL_CONFIG],

--- a/javascript/packages/core/config/entities/run/run.ts
+++ b/javascript/packages/core/config/entities/run/run.ts
@@ -81,7 +81,7 @@ const RETRY_AS_RESUME_OPERATIONS: MiddlewareOperation[] = [
 
 export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'runs',
-  name: 'Runs',
+  name: 'runs',
   service: 'pipelineRun',
   state: 'active',
   views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],

--- a/javascript/packages/core/config/entities/targets/target.ts
+++ b/javascript/packages/core/config/entities/targets/target.ts
@@ -6,7 +6,7 @@ import type { PhaseEntityConfig } from '#core/types/common/studio-types';
 
 export const TARGET_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'targets',
-  name: 'Targets',
+  name: 'targets',
   service: 'inferenceServer',
   state: 'active',
   views: [TARGET_LIST_CONFIG, TARGET_DETAIL_CONFIG],

--- a/javascript/packages/core/config/entities/trigger/trigger.ts
+++ b/javascript/packages/core/config/entities/trigger/trigger.ts
@@ -16,7 +16,7 @@ const isKillable = (record: unknown) => {
 
 export const TRIGGER_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'triggers',
-  name: 'Triggers',
+  name: 'triggers',
   service: 'triggerRun',
   state: 'active',
   views: [TRIGGER_LIST_CONFIG, TRIGGER_DETAIL_CONFIG],

--- a/javascript/packages/core/config/phases/data.ts
+++ b/javascript/packages/core/config/phases/data.ts
@@ -16,7 +16,7 @@ export const DATA_PHASE: PhaseConfig = {
     { ...RUN_ENTITY_CONFIG, state: 'disabled' },
     {
       id: 'datasources',
-      name: 'Data Sources',
+      name: 'data sources',
       state: 'disabled',
       service: 'datasource',
       views: [],

--- a/javascript/packages/core/config/phases/train.ts
+++ b/javascript/packages/core/config/phases/train.ts
@@ -21,14 +21,14 @@ export const TRAIN_PHASE: PhaseConfig = {
     MODEL_ENTITY_CONFIG,
     {
       id: 'evaluations',
-      name: 'Evaluations',
+      name: 'evaluations',
       state: 'disabled',
       service: 'evaluationReport',
       views: [],
     },
     {
       id: 'notebooks',
-      name: 'Notebooks',
+      name: 'notebooks',
       state: 'disabled',
       service: 'notebook',
       views: [],

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -2,6 +2,7 @@ import { LayersManager } from 'baseui/layer';
 import { SnackbarProvider } from 'baseui/snackbar';
 
 import { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
+import { DisplayProvider } from '#core/providers/display-provider/display-provider';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -45,7 +46,18 @@ export function CoreApp({ dependencies }: Props) {
                     links={dependencies.navigationBar?.links}
                     onSignOut={dependencies.navigationBar?.onSignOut}
                   />
-                  <Router />
+                  {/*
+                    Routed page content is `content` by default (prose read as a
+                    sentence, rendered as written) — see `DisplayContextType`.
+                    Structural nav chrome nested anywhere below (BreadcrumbBar,
+                    tab-title strips) declares its own narrower `nav` override
+                    rather than requiring every future page to remember to wrap
+                    itself; `useEntityName` just reads whichever region a
+                    component happens to render inside.
+                  */}
+                  <DisplayProvider type="content">
+                    <Router />
+                  </DisplayProvider>
                 </UserProvider>
               </IconProvider>
             </ErrorProvider>

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -49,10 +49,11 @@ export function CoreApp({ dependencies }: Props) {
                   {/*
                     Routed page content is `content` by default (prose read as a
                     sentence, rendered as written) — see `DisplayContextType`.
-                    Structural nav chrome nested anywhere below (BreadcrumbBar,
-                    tab-title strips) declares its own narrower `nav` override
-                    rather than requiring every future page to remember to wrap
-                    itself; `useEntityName` just reads whichever region a
+                    Elements that are wayfinding chrome despite living inside
+                    page content (BreadcrumbBar, phase-entity-view's tab titles,
+                    phase-card's entity links) declare their own narrower `nav`
+                    override rather than requiring every future page to remember
+                    to wrap itself; `useEntityName` just reads whichever region a
                     component happens to render inside.
                   */}
                   <DisplayProvider type="content">

--- a/javascript/packages/core/index.tsx
+++ b/javascript/packages/core/index.tsx
@@ -2,7 +2,6 @@ import { LayersManager } from 'baseui/layer';
 import { SnackbarProvider } from 'baseui/snackbar';
 
 import { NavigationBar } from '#core/components/navigation-bar/navigation-bar';
-import { DisplayProvider } from '#core/providers/display-provider/display-provider';
 import { ErrorProvider } from '#core/providers/error-provider/error-provider';
 import { IconProvider } from '#core/providers/icon-provider/icon-provider';
 import { ServiceProvider } from '#core/providers/service-provider/service-provider';
@@ -46,19 +45,7 @@ export function CoreApp({ dependencies }: Props) {
                     links={dependencies.navigationBar?.links}
                     onSignOut={dependencies.navigationBar?.onSignOut}
                   />
-                  {/*
-                    Routed page content is `content` by default (prose read as a
-                    sentence, rendered as written) — see `DisplayContextType`.
-                    Elements that are wayfinding chrome despite living inside
-                    page content (BreadcrumbBar, phase-entity-view's tab titles,
-                    phase-card's entity links) declare their own narrower `nav`
-                    override rather than requiring every future page to remember
-                    to wrap itself; `useEntityName` just reads whichever region a
-                    component happens to render inside.
-                  */}
-                  <DisplayProvider type="content">
-                    <Router />
-                  </DisplayProvider>
+                  <Router />
                 </UserProvider>
               </IconProvider>
             </ErrorProvider>


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [x] Bug Fix

**What changed?**
`phase-entity-view`'s tabs and `phase-card`'s entity links were the last two spots still rendering `entity.name` verbatim — that only read correctly because their config values had Title Case baked in from before nav casing moved to render time. Routes both through `formatEntityName(name, 'nav')`, and lowercases the remaining pre-cased config entries so `name` is the lowercase canonical form everywhere, matching the breadcrumb bar.

Stacked on `craig.marker/breadcrumb-title-case`.

**Why?**
Lowercase-in-config, Title-Case-at-render is the convention this PR's base branch established; leaving these two consumers pre-cased meant the casing rule was inconsistent depending on which component rendered the name, and blocked ever changing the nav casing convention in one place.

**How did you test it?**
I ran the full test suite, typecheck, and lint locally — all clean.

**Potential risks**
None — display-only formatting change; the config value itself and its semantics are untouched.

**Breaking Changes**

- [x] No breaking changes

**Release notes**
N/A

**Documentation Changes**
N/A