### PR TITLE
fix(ray): stop re-entering termination flow for already-terminated RayClusters

### DIFF
--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -102,6 +102,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 
+	// A cluster in the terminal TERMINATED state has nothing left to reconcile: the remote
+	// RayCluster is gone and every termination step below is a no-op. Marking it immutable
+	// hands it to the ingester, which moves it to metadata storage and deletes it from ETCD,
+	// permanently ending reconciliation instead of re-entering the termination flow on every
+	// watch event.
+	if rayCluster.Status.State == v2pb.RAY_CLUSTER_STATE_TERMINATED {
+		if !utils.IsImmutable(&rayCluster) {
+			utils.MarkImmutable(&rayCluster)
+			if err := r.Update(ctx, &rayCluster, &metav1.UpdateOptions{}); err != nil {
+				logger.Error(err, "failed to mark terminated cluster immutable")
+				return ctrl.Result{}, err
+			}
+			logger.Info("marked terminated cluster immutable")
+		}
+		logger.V(1).Info("cluster is terminated, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	// Create a copy of the original RayCluster for comparison
 	originalRayCluster := rayCluster.DeepCopy()
 

--- a/go/components/ray/cluster/controller_test.go
+++ b/go/components/ray/cluster/controller_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client/clientmocks"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
 	matypes "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/types"
@@ -991,6 +992,74 @@ func TestReconcilerReconcile(t *testing.T) {
 				}
 				assert.NotNil(t, killedCond, "KilledCondition should exist")
 				assert.Equal(t, apipb.CONDITION_STATUS_TRUE, killedCond.Status)
+			},
+		},
+		{
+			name: "Cluster already terminated - marks immutable and skips reconciliation",
+			setup: func() []client.Object {
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayClusterName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayClusterSpec{
+						RayVersion: "2.3.1",
+						Head:       &v2pb.RayHeadSpec{},
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_TERMINATED,
+					},
+				}
+				return []client.Object{cluster}
+			},
+			// No expectations are set on the federated client mock: any call (e.g.
+			// DeleteJobCluster) fails the test, proving the termination flow is not
+			// re-entered for a cluster that is already terminated.
+			setupMocks:      func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_TERMINATED,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				assert.True(t, utils.IsImmutable(cluster), "terminated cluster should be marked immutable")
+			},
+		},
+		{
+			name: "Cluster already terminated and immutable - no-op",
+			setup: func() []client.Object {
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       rayClusterName,
+						Namespace:  testNamespace,
+						Generation: 1,
+					},
+					Spec: v2pb.RayClusterSpec{
+						RayVersion: "2.3.1",
+						Head:       &v2pb.RayHeadSpec{},
+					},
+					Status: v2pb.RayClusterStatus{
+						State: v2pb.RAY_CLUSTER_STATE_TERMINATED,
+					},
+				}
+				utils.MarkImmutable(cluster)
+				return []client.Object{cluster}
+			},
+			setupMocks:      func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_TERMINATED,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				assert.True(t, utils.IsImmutable(cluster), "immutable annotation should remain set")
+				// The fake client's object tracker seeds ResourceVersion as "999" and
+				// bumps it on every Update; an unchanged value proves no Update was
+				// issued for a cluster that is already terminated and immutable.
+				assert.Equal(t, "999", cluster.ResourceVersion, "no Update should be issued for an already-immutable terminated cluster")
 			},
 		},
 		{


### PR DESCRIPTION
## Problem

`controllermgr` is burning queue capacity on already-terminated RayClusters. Production
logs show the same cluster (e.g. `uf-ray-q7gm4` in `av-labs-data-lake`, also `uf-ray-gb8d9`,
`uf-ray-d88x7`, `uf-ray-ndb9j`) logging "processed cluster termination" + "cluster cleaned
up successfully" three times in 14 seconds, each under a different reconcile ID — i.e. the
full termination flow re-running every ~7s indefinitely.

`shouldTerminateCluster` returns true whenever `SucceededCondition != UNKNOWN`
(`go/components/ray/cluster/controller.go`), and that condition stays non-`UNKNOWN` forever
once a cluster has terminated. So every watch event on an already-terminated RayCluster
re-enters `processClusterTermination`, which re-runs the federated `DeleteJobCluster` call
against a compute cluster that's already gone and rewrites status — which produces the next
watch event. Nothing ever marks the object immutable, so it never leaves ETCD and the loop
never stops.

## Fix

Add an early return at the top of `Reconcile`, right after the initial `Get` and before the
termination check: if `Status.State == RAY_CLUSTER_STATE_TERMINATED`, mark the object
immutable (if not already) via a plain `Update` and return. The ingester
(`go/components/ingester/controller.go`) is registered for all `v2pb.CrdObjects`, including
RayCluster, and on seeing the immutable annotation it upserts the object into metadata
storage and deletes it from K8s/ETCD — permanently ending reconciliation instead of
re-entering termination on every subsequent watch event.

This mirrors the existing pattern in `go/components/ray/job/controller.go`, which already
marks terminal RayJobs immutable.

## On the underlying "why does this reconcile every 7s" mechanism

Reading `processClusterTermination` statically, a *fully* terminated cluster (`Succeeded !=
UNKNOWN`, `Killing=FALSE`, `Killed=TRUE`) should make all three of its sub-steps
(`setClusterSuccessConditionIfRequired`, `setClusterKillIfRequired`, `cleanupCluster`)
no-ops, since each one's guard checks the current condition value and returns early. So on
paper the object should quiesce after the terminal status write, with no further watch
events. I confirmed two relevant details that are consistent with the code but don't fully
explain the storm by themselves:

- `jobsutils.GetCondition` matches purely by condition `Type` and ignores the `generation`
  argument entirely, so a condition set on one generation is still read back correctly on
  later ones — generation drift is not the cause.
- `jobsutils.UpdateStatusWithRetries` re-`Get`s a **fresh** copy of the object and applies
  the mutator to that copy, not to the caller's in-memory object. That fresh copy is what
  gets persisted via `UpdateStatus`.
- The `Killing=FALSE` write in `cleanupCluster` (existing code, not touched by this PR) omits
  `Generation` in its `ConditionUpdateParams`, unlike sibling call sites. I verified this only
  affects `ObservedGeneration` bookkeeping on that condition (`UpdateCondition` unconditionally
  sets `Status` regardless of `Generation`), so it doesn't by itself explain the FALSE write
  failing to land or be read back.

Given three independent reconcile IDs hit `cleanupCluster`'s terminal log line within 14
seconds, the more likely explanation is that reconciles are observing a stale `Killing=TRUE`
read (e.g. controller-runtime cache/watch propagation lag racing the immediately-preceding
status write) rather than the FALSE write never landing at all. I did not chase this further
since the fix in this PR does not depend on which of these is true: once a cluster reaches
`RAY_CLUSTER_STATE_TERMINATED`, it now short-circuits before any of `processClusterTermination`
runs, regardless of what `Killing`/`Killed` read as.

Related: PR #2006 (`raycluster-terminate-missing-on-remote`) handles the separate case where
`GetJobClusterStatus` returns not-found because the cluster is gone from the remote compute
cluster — that path marks the cluster FAILED and immutable before it ever reaches
`RAY_CLUSTER_STATE_TERMINATED`. This PR is cut from `main` and does not include that change;
the two are complementary, not overlapping.

## Verification

- `bazel build //go/components/ray/...` passes.
- `bazel test //go/components/ray/cluster:go_default_test` passes, including two new cases:
  - a RayCluster already in `RAY_CLUSTER_STATE_TERMINATED`: reconcile returns no error and no
    requeue, the immutable annotation ends up set, and no federated-client call is made (no
    mock expectation is set on `DeleteJobCluster`/`CreateJobCluster`/`GetJobClusterStatus`, so
    gomock fails the test if any of them is called).
  - the same, but already immutable going in: reconcile is a full no-op, verified by asserting
    the object's `ResourceVersion` is unchanged (the fake client's tracker bumps
    `ResourceVersion` on every `Update`).
- All pre-existing test cases in the package continue to pass unmodified.
