### PR TITLE
fix(ray): drop reconciles for immutable RayCluster/RayJob objects

### DIFF
--- a/go/components/ray/cluster/BUILD.bazel
+++ b/go/components/ray/cluster/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/utils:go_default_library",
         "//go/components/jobs/client/clientmocks:go_default_library",
         "//go/components/jobs/cluster:go_default_library",

--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -103,6 +103,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{RequeueAfter: requeueAfter}, err
 	}
 
+	// An immutable RayCluster has reached a terminal state and is being moved to metadata
+	// storage by the ingester (which will delete it from ETCD). Skip reconciliation so we
+	// neither waste queue capacity nor re-trigger ourselves by rewriting a terminal object.
+	if utils.IsImmutable(&rayCluster) {
+		logger.Info("RayCluster is immutable, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	// Create a copy of the original RayCluster for comparison
 	originalRayCluster := rayCluster.DeepCopy()
 

--- a/go/components/ray/cluster/controller_test.go
+++ b/go/components/ray/cluster/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/michelangelo-ai/michelangelo/go/api"
 	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
 	v2pb "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
 	corev1 "k8s.io/api/core/v1"
@@ -192,6 +193,38 @@ func TestReconcilerReconcile(t *testing.T) {
 				assert.Equal(t, time.Duration(0), res.RequeueAfter)
 			},
 			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {},
+		},
+		{
+			// An immutable RayCluster must be skipped entirely. A non-immutable
+			// cluster with this spec would be enqueued (EnqueuedCondition set and a
+			// requeue); a cluster left in its seeded INVALID state with no status
+			// conditions and no requeue proves reconciliation was short-circuited by
+			// the immutable check.
+			name: "immutable cluster is skipped",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				cluster := &v2pb.RayCluster{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        rayClusterName,
+						Namespace:   testNamespace,
+						Generation:  1,
+						Annotations: map[string]string{api.ImmutableAnnotation: "true"},
+					},
+					Spec: createRayClusterSpec(),
+				}
+				objects = append(objects, cluster)
+				return objects
+			},
+			setupMocks:      func(mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache, msq *mockSchedulerQueue) {},
+			expectedState:   v2pb.RAY_CLUSTER_STATE_INVALID,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, cluster *v2pb.RayCluster) {
+				assert.Empty(t, cluster.Status.StatusConditions, "immutable cluster must not be reconciled")
+			},
 		},
 		{
 			name: "Cluster should be enqueued",

--- a/go/components/ray/job/BUILD.bazel
+++ b/go/components/ray/job/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api:go_default_library",
         "//go/api/utils:go_default_library",
         "//go/components/jobs/client/clientmocks:go_default_library",
         "//go/components/jobs/cluster:go_default_library",

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -75,6 +75,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		res.RequeueAfter = requeueAfter
 		return res, err
 	}
+
+	// An immutable RayJob has reached a terminal state and is being moved to metadata
+	// storage by the ingester (which will delete it from ETCD). Skip reconciliation so we
+	// neither waste queue capacity nor re-trigger ourselves by rewriting a terminal object.
+	if utils.IsImmutable(&rayJob) {
+		logger.Info("RayJob is immutable, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	// original copy of ray job to determine if we need to update the status
 	originalRayJob := rayJob.DeepCopy()
 	// Initialize status conditions, as they will be nil for new jobs

--- a/go/components/ray/job/controller_test.go
+++ b/go/components/ray/job/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/michelangelo-ai/michelangelo/go/api"
 	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client/clientmocks"
 	jobscluster "github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
@@ -122,6 +123,39 @@ func TestReconciler_Reconcile(t *testing.T) {
 				assert.Equal(t, time.Duration(0), res.RequeueAfter)
 			},
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {},
+		},
+		{
+			// An immutable RayJob must be skipped entirely. A non-immutable job with
+			// no cluster set would be marked FAILED ("cluster is not set"); a job left
+			// in its seeded INVALID state with no status conditions and no requeue
+			// proves reconciliation was short-circuited by the immutable check.
+			name: "immutable job is skipped",
+			setup: func() []client.Object {
+				objects := make([]client.Object, 0)
+				rayJob := &v2pb.RayJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        rayJobName,
+						Namespace:   testNamespace,
+						Generation:  1,
+						Annotations: map[string]string{api.ImmutableAnnotation: "true"},
+					},
+					Spec: v2pb.RayJobSpec{
+						Cluster: nil,
+					},
+				}
+				objects = append(objects, rayJob)
+				return objects
+			},
+			setupMocks:      func(ctrl *gomock.Controller, mfc *clientmocks.MockFederatedClient, mcc *mockClusterCache) {},
+			expectedState:   v2pb.RAY_JOB_STATE_INVALID,
+			expectedMessage: "",
+			errorAssertion:  require.NoError,
+			postCheck: func(res ctrl.Result) {
+				assert.Equal(t, time.Duration(0), res.RequeueAfter)
+			},
+			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {
+				assert.Empty(t, job.Status.StatusConditions, "immutable job must not be reconciled")
+			},
 		},
 		{
 			name: "Cluster not found",


### PR DESCRIPTION
## Problem

Once a RayCluster or RayJob reaches a terminal state it is marked immutable
(`michelangelo/Immutable` annotation) and handed off to the ingester, which copies it
into metadata storage and deletes it from K8s/ETCD. Until that delete lands the object
is logically frozen — but the controller still reconciles it on every watch event and
requeue. That is wasted queue capacity, and a reconcile that rewrites status produces
another event, which can re-trigger itself.

This is one of a few parallel fixes to a production reconcile storm (terminated
RayClusters and RayJobs re-reconciling every few seconds). This change is the backstop:
it guarantees an immutable object is not reconciled again, regardless of which code path
made it immutable.

## Fix

Check immutability inside `Reconcile`, immediately after the object is fetched, in both
controllers:

```go
if utils.IsImmutable(&rayJob) {
    logger.Info("RayJob is immutable, skipping reconciliation")
    return ctrl.Result{}, nil
}
```

The guard sits right after the `Get` (and its NotFound handling), before any status copy
or mutation, so an immutable object short-circuits with no requeue and no status write.
This mirrors the existing precedent in `go/components/revision/controller.go`, which does
the same immutability check near the top of its `Reconcile`.

An earlier revision of this change used a `WithEventFilter` predicate in `Register`
instead. The in-`Reconcile` check was chosen to match the Revision controller precedent,
to keep the guard on the object the reconciler actually operates on, and to avoid
filtering the shared watch stream.

## Test plan

Each `controller_test.go` gains a reconcile-level table case ("immutable job is skipped"
/ "immutable cluster is skipped"): an immutable object that would otherwise be acted on
(a RayJob with no cluster would be marked FAILED; a RayCluster with a full spec would be
enqueued) is instead left in its seeded state with no status conditions and no requeue,
proving reconciliation was short-circuited.

- `bazel build //go/components/ray/...` — passes
- `bazel test //go/components/ray/...` — all pass (`cluster`, `job`, `kuberay`), including the new skip subtests
