### PR TITLE
fix(go): stop pairing non-zero ctrl.Result with non-nil error in Ray controllers

### DIFF
--- a/go/components/ray/cluster/controller.go
+++ b/go/components/ray/cluster/controller.go
@@ -99,7 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		// Requeue for errors other than not found
 		logger.Error(err, "failed to get ray cluster")
-		return ctrl.Result{RequeueAfter: requeueAfter}, err
+		return ctrl.Result{}, err
 	}
 
 	// Create a copy of the original RayCluster for comparison
@@ -111,7 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		err := r.processClusterTermination(ctx, &rayCluster, logger)
 		if err != nil {
 			logger.Error(err, "cluster termination could not be processed")
-			return ctrl.Result{RequeueAfter: requeueAfter}, err
+			return ctrl.Result{}, err
 		}
 		logger.Info("processed cluster termination")
 		return ctrl.Result{}, nil
@@ -121,7 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	err := r.enqueueIfRequired(ctx, &rayCluster, logger)
 	if err != nil {
 		logger.Error(err, "failed to enqueue cluster")
-		return ctrl.Result{RequeueAfter: requeueAfter}, err
+		return ctrl.Result{}, err
 	}
 
 	// Wait for scheduling
@@ -162,9 +162,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 					&metav1.UpdateOptions{},
 				); err != nil {
 					logger.Error(err, "failed to update status after creation failure")
+					return ctrl.Result{}, err
 				}
 
-				return ctrl.Result{RequeueAfter: requeueAfter}, err
+				return ctrl.Result{RequeueAfter: requeueAfter}, nil
 			}
 		}
 
@@ -185,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			&metav1.UpdateOptions{},
 		); err != nil {
 			logger.Error(err, "failed to update launched condition")
-			return ctrl.Result{RequeueAfter: requeueAfter}, err
+			return ctrl.Result{}, err
 		}
 		logger.Info("cluster creation initiated")
 		return ctrl.Result{RequeueAfter: requeueAfter}, nil
@@ -200,12 +201,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			return ctrl.Result{RequeueAfter: requeueAfter}, nil
 		}
 		logger.Error(err, "failed to get cluster status")
-		return ctrl.Result{RequeueAfter: requeueAfter}, err
+		return ctrl.Result{}, err
 	}
 
 	if err := r.applyRayClusterStatus(&rayCluster, clusterStatus, logger, &res); err != nil {
 		logger.Error(err, "failed to apply cluster status")
-		return ctrl.Result{RequeueAfter: requeueAfter}, err
+		return ctrl.Result{}, err
 	}
 
 	// Update the RayCluster status if any changes occurred
@@ -219,7 +220,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			&metav1.UpdateOptions{},
 		); err != nil {
 			logger.Error(err, "failed to update ray cluster status")
-			return res, fmt.Errorf("update ray cluster status for %q: %w", req.NamespacedName, err)
+			return ctrl.Result{}, fmt.Errorf("update ray cluster status for %q: %w", req.NamespacedName, err)
 		}
 	}
 

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -71,8 +71,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if utils.IsNotFoundError(err) {
 			return ctrl.Result{}, nil
 		}
-		res.RequeueAfter = requeueAfter
-		return res, err
+		return ctrl.Result{}, err
 	}
 	// original copy of ray job to determine if we need to update the status
 	originalRayJob := rayJob.DeepCopy()
@@ -97,8 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		err := r.Status().Update(ctx, &rayJob)
 		if err != nil {
 			logger.Error(err, "failed to update status")
-			res.RequeueAfter = requeueAfter
-			return res, err
+			return ctrl.Result{}, err
 		}
 	}
 


### PR DESCRIPTION
## Problem

Both Ray controllers repeatedly returned a non-zero `ctrl.Result` **and** a
non-nil error from `Reconcile`, e.g.:

```go
return ctrl.Result{RequeueAfter: requeueAfter}, err
```

controller-runtime ignores the `Result` whenever `err != nil` and requeues
with exponential backoff instead. Production logs confirm this was firing
constantly: `"Reconciler returned both a non-zero result and a non-nil
error"`. So the `RequeueAfter: 10s` on these lines was dead code that
misrepresented the actual retry behaviour to anyone reading it, and it
generated warning-log noise on every single error.

## Fix

Return the error alone on every path where the paired error is guaranteed
non-nil — `return ctrl.Result{}, err` — and let exponential backoff own the
retry. This is behaviour-preserving: the `Result` was already being
discarded by controller-runtime on these paths.

Touched:
- `go/components/ray/cluster/controller.go` — 7 direct error returns, plus
  one `res`-carrying return (`return res, fmt.Errorf(...)`) where `res` may
  hold a `RequeueAfter` set earlier by `applyRayClusterStatus`.
- `go/components/ray/job/controller.go` — 2 returns of the form
  `res.RequeueAfter = requeueAfter; return res, err`, simplified to
  `return ctrl.Result{}, err` (the now-dead assignment is removed since the
  Result is discarded either way).

One spot needed more care than a blind text swap: in the cluster controller,
when `federatedClient.CreateJobCluster` fails, the handler reassigns the same
`err` variable with the result of a follow-up `UpdateStatusWithRetries` call
(`if err = jobsutils.UpdateStatusWithRetries(...); err != nil { ... }`)
before falling through to the return. That means the trailing return could
carry a **nil** error when the status update succeeded — a legitimate
`Result+nil` pairing that must be left alone, not the antipattern. Fixed by
returning early only inside the genuine-error branch and letting the
success path fall through to its own `return ctrl.Result{RequeueAfter:
requeueAfter}, nil`, so both behaviours are preserved exactly as before.

Left untouched (as intended): every return pairing a non-zero `Result` with
a **nil** error (not-yet-scheduled, cluster-creation-initiated, cluster
not found on remote, etc.) — those are the legitimate uses of
`RequeueAfter` and are not part of this antipattern.

## Verification

- `bazel build //go/components/ray/...` — succeeds.
- `bazel test //go/components/ray/cluster:go_default_test
  //go/components/ray/job:go_default_test` — both pass.
- No test assertions needed updating: every existing table-driven test case
  in both `controller_test.go` files asserts `require.NoError`, so none of
  them exercise the hard-error return paths this change touches.
- The one case that *does* exercise the tricky reassigned-`err` spot —
  `"Cluster creation fails"` in `cluster/controller_test.go` — already
  asserts `require.NoError` with a comment noting *"Status update succeeds,
  so no error is returned"*, and still asserts `res.RequeueAfter ==
  requeueAfter`. This passes unchanged, confirming the restructuring in that
  spot preserved behaviour exactly.

## Scope

This is a mechanical, behaviour-preserving cleanup only. It does not touch
the terminated-cluster early-return fix, RayJob immutability handling, or
any event-filter/predicate changes — those are separate, parallel efforts.
