### PR TITLE
fix(ray): persist RayJob immutable annotation and fix always-dirty status check

### DIFF
--- a/go/components/ray/job/BUILD.bazel
+++ b/go/components/ray/job/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     srcs = ["controller_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//go/api/utils:go_default_library",
         "//go/components/jobs/client/clientmocks:go_default_library",
         "//go/components/jobs/cluster:go_default_library",
         "//go/components/jobs/common/types:go_default_library",

--- a/go/components/ray/job/BUILD.bazel
+++ b/go/components/ray/job/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -97,19 +97,26 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			res.RequeueAfter = requeueAfter
 			return res, err
 		}
+	}
 
-		if isTerminalRayJobState(rayJob.Status.State) && !utils.IsImmutable(&rayJob) {
-			// Annotations are metadata, so Status().Update above never persists
-			// them. Persist with a plain Update, and do it after the status
-			// write using the resourceVersion that refreshed: doing it first
-			// would bump resourceVersion and hand back the pre-update status in
-			// the response, clobbering the status we just persisted.
-			utils.MarkImmutable(&rayJob)
-			if err := r.Update(ctx, &rayJob); err != nil {
-				// Log only: don't turn an already-successful status write into
-				// a failed reconcile over a best-effort annotation.
-				logger.Error(err, "failed to persist immutable annotation")
-			}
+	// Checked independently of the dirty-check above -- and on every
+	// reconcile, not just the pass that first reached a terminal state --
+	// so a job stuck terminal-but-mutable (e.g. a prior annotation write
+	// failed, or it lands on the same terminal status every pass, as with a
+	// permanently missing cluster spec) keeps getting retried instead of
+	// being skipped forever once its status stops changing.
+	if isTerminalRayJobState(rayJob.Status.State) && !utils.IsImmutable(&rayJob) {
+		// Annotations are metadata, so Status().Update above never persists
+		// them; persist with a plain Update. This is safe whether or not the
+		// status write above ran: a plain Update never touches .status, so
+		// there's nothing for it to clobber, and rayJob's resourceVersion is
+		// current either way -- refreshed by Status().Update if it ran, or
+		// still the one from the Get at the top of Reconcile if it didn't.
+		utils.MarkImmutable(&rayJob)
+		if err := r.Update(ctx, &rayJob); err != nil {
+			// Log only: don't turn an already-successful status write into a
+			// failed reconcile over a best-effort annotation.
+			logger.Error(err, "failed to persist immutable annotation")
 		}
 	}
 

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -89,16 +89,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		r.reconcileRayJobWithCluster(ctx, logger, &rayJob, &res)
 	}
 
-	if !reflect.DeepEqual(originalRayJob, rayJob) {
+	if !reflect.DeepEqual(originalRayJob.Status, rayJob.Status) {
 		// update the resource in ETCD
-		if isTerminalRayJobState(rayJob.Status.State) {
-			utils.MarkImmutable(&rayJob)
-		}
 		err := r.Status().Update(ctx, &rayJob)
 		if err != nil {
 			logger.Error(err, "failed to update status")
 			res.RequeueAfter = requeueAfter
 			return res, err
+		}
+
+		if isTerminalRayJobState(rayJob.Status.State) && !utils.IsImmutable(&rayJob) {
+			// Annotations are metadata, so Status().Update above never persists
+			// them. Persist with a plain Update, and do it after the status
+			// write using the resourceVersion that refreshed: doing it first
+			// would bump resourceVersion and hand back the pre-update status in
+			// the response, clobbering the status we just persisted.
+			utils.MarkImmutable(&rayJob)
+			if err := r.Update(ctx, &rayJob); err != nil {
+				// Log only: don't turn an already-successful status write into
+				// a failed reconcile over a best-effort annotation.
+				logger.Error(err, "failed to persist immutable annotation")
+			}
 		}
 	}
 

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -99,22 +100,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// Mark terminal jobs immutable. Intentionally separate from the status
-	// dirty-check above and run on every reconcile -- not just the pass that
-	// first turned the job terminal. A terminal job's status usually stops
-	// changing, so a check nested in the dirty-check would fire at most once;
-	// if that single write didn't land, the job would stay terminal-but-mutable
-	// forever and the ingester would never collect it.
+	// Mark terminal jobs immutable so the ingester can move them to metadata
+	// storage and delete the CR. Kept outside the status dirty-check above and
+	// attempted on every reconcile while terminal-but-mutable: a terminal job's
+	// status stops changing, so a marker nested in that check would fire at most
+	// once, and a single dropped write would strand the job forever.
 	if isTerminalRayJobState(rayJob.Status.State) && !utils.IsImmutable(&rayJob) {
-		// The immutable marker is an annotation (metadata). Status().Update
-		// above writes only the /status subresource and cannot persist it, so
-		// use a plain Update. Ordering is safe: a plain Update leaves /status
-		// untouched, and rayJob's resourceVersion is current either way.
-		utils.MarkImmutable(&rayJob)
-		if err := r.Update(ctx, &rayJob); err != nil {
-			// Best-effort: don't fail the reconcile (losing the status write)
-			// over the annotation; the guard above retries on a later reconcile.
+		if err := r.markImmutableIfTerminal(ctx, &rayJob); err != nil {
+			// The status write above already committed; requeue to retry the
+			// annotation rather than dropping it best-effort.
 			logger.Error(err, "failed to persist immutable annotation")
+			res.RequeueAfter = requeueAfter
+			return res, err
 		}
 	}
 
@@ -277,6 +274,32 @@ func (r *Reconciler) applyRayJobStatus(
 	if !isTerminalRayJobState(jobStatus.Ray.State) {
 		res.RequeueAfter = requeueAfter
 	}
+}
+
+// markImmutableIfTerminal persists the michelangelo/Immutable annotation on a
+// terminal RayJob so the ingester can move it to metadata storage and delete the
+// CR; afterwards Get returns NotFound and reconciliation stops. It is a no-op if
+// the job is already immutable or is no longer terminal.
+//
+// The marker is an annotation (metadata), which Status().Update cannot persist,
+// so this uses a plain Update. It re-fetches the object first -- the caller just
+// wrote the status subresource -- and retries on conflict, keeping the
+// resourceVersion current against that write and any concurrent writer.
+func (r *Reconciler) markImmutableIfTerminal(ctx context.Context, rayJob *v2pb.RayJob) error {
+	if err := retry.OnError(retry.DefaultRetry, jobsutils.IsRetriableError, func() error {
+		latest := &v2pb.RayJob{}
+		if err := r.Get(ctx, types.NamespacedName{Namespace: rayJob.Namespace, Name: rayJob.Name}, latest); err != nil {
+			return err
+		}
+		if utils.IsImmutable(latest) || !isTerminalRayJobState(latest.Status.State) {
+			return nil
+		}
+		utils.MarkImmutable(latest)
+		return r.Update(ctx, latest)
+	}); err != nil {
+		return fmt.Errorf("failed to mark ray job immutable: %w", err)
+	}
+	return nil
 }
 
 func isTerminalRayJobState(state v2pb.RayJobState) bool {

--- a/go/components/ray/job/controller.go
+++ b/go/components/ray/job/controller.go
@@ -99,23 +99,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	// Checked independently of the dirty-check above -- and on every
-	// reconcile, not just the pass that first reached a terminal state --
-	// so a job stuck terminal-but-mutable (e.g. a prior annotation write
-	// failed, or it lands on the same terminal status every pass, as with a
-	// permanently missing cluster spec) keeps getting retried instead of
-	// being skipped forever once its status stops changing.
+	// Mark terminal jobs immutable. Intentionally separate from the status
+	// dirty-check above and run on every reconcile -- not just the pass that
+	// first turned the job terminal. A terminal job's status usually stops
+	// changing, so a check nested in the dirty-check would fire at most once;
+	// if that single write didn't land, the job would stay terminal-but-mutable
+	// forever and the ingester would never collect it.
 	if isTerminalRayJobState(rayJob.Status.State) && !utils.IsImmutable(&rayJob) {
-		// Annotations are metadata, so Status().Update above never persists
-		// them; persist with a plain Update. This is safe whether or not the
-		// status write above ran: a plain Update never touches .status, so
-		// there's nothing for it to clobber, and rayJob's resourceVersion is
-		// current either way -- refreshed by Status().Update if it ran, or
-		// still the one from the Get at the top of Reconcile if it didn't.
+		// The immutable marker is an annotation (metadata). Status().Update
+		// above writes only the /status subresource and cannot persist it, so
+		// use a plain Update. Ordering is safe: a plain Update leaves /status
+		// untouched, and rayJob's resourceVersion is current either way.
 		utils.MarkImmutable(&rayJob)
 		if err := r.Update(ctx, &rayJob); err != nil {
-			// Log only: don't turn an already-successful status write into a
-			// failed reconcile over a best-effort annotation.
+			// Best-effort: don't fail the reconcile (losing the status write)
+			// over the annotation; the guard above retries on a later reconcile.
 			logger.Error(err, "failed to persist immutable annotation")
 		}
 	}

--- a/go/components/ray/job/controller_test.go
+++ b/go/components/ray/job/controller_test.go
@@ -1097,3 +1097,102 @@ func TestReconciler_Reconcile_NoOpSkipsStatusWrite(t *testing.T) {
 	// Update fired -- and neither should, since nothing actually changed.
 	assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "no-op reconcile must not write the RayJob")
 }
+
+// TestReconciler_Reconcile_RetriesImmutableAnnotationWhenStatusUnchanged
+// covers a RayJob that is already terminal but not yet immutable -- e.g. a
+// prior reconcile persisted the terminal status but its immutable-annotation
+// write failed -- and whose status happens not to change on this pass. The
+// immutable check must not be gated behind the status dirty-check, or a job
+// like this would stay terminal-but-mutable forever once its status stopped
+// changing.
+func TestReconciler_Reconcile_RetriesImmutableAnnotationWhenStatusUnchanged(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	kubescheme.AddToScheme(scheme)
+	v2pb.AddToScheme(scheme)
+
+	rayJob := &v2pb.RayJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       rayJobName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+		Spec: v2pb.RayJobSpec{
+			Cluster: &apipb.ResourceIdentifier{
+				Name:      testClusterName,
+				Namespace: testNamespace,
+			},
+			Entrypoint: "echo Hello World",
+		},
+		Status: v2pb.RayJobStatus{
+			// Already terminal, and deliberately missing the immutable
+			// annotation -- simulating a prior reconcile whose status write
+			// succeeded but whose annotation write did not.
+			State:     v2pb.RAY_JOB_STATE_SUCCEEDED,
+			JobStatus: "SUCCEEDED",
+			StatusConditions: []*apipb.Condition{
+				{
+					Type:   "Launched",
+					Status: apipb.CONDITION_STATUS_TRUE,
+				},
+			},
+		},
+	}
+	cluster := &v2pb.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testClusterName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+		Status: v2pb.RayClusterStatus{
+			State: v2pb.RAY_CLUSTER_STATE_READY,
+			Assignment: &v2pb.AssignmentInfo{
+				Cluster: assignedCluster,
+			},
+		},
+	}
+
+	objects := make([]client.Object, 0)
+	objects = append(objects, rayJob)
+	objects = append(objects, cluster)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithStatusSubresource(objects...).Build()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFedClient := clientmocks.NewMockFederatedClient(mockCtrl)
+	mockCache := newMockClusterCache()
+	mockCache.addCluster(assignedCluster, &v2pb.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: assignedCluster,
+		},
+	})
+	// The federated status poll reports back exactly the terminal status
+	// already stored, so there is nothing new for the status dirty-check to
+	// catch -- only the pending immutable annotation.
+	mockFedClient.EXPECT().GetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&jobtypes.JobStatus{
+		Ray: &v2pb.RayJobStatus{
+			JobStatus: "SUCCEEDED",
+			State:     v2pb.RAY_JOB_STATE_SUCCEEDED,
+		},
+	}, nil)
+
+	r := &Reconciler{
+		Client:          fakeClient,
+		federatedClient: mockFedClient,
+		clusterCache:    mockCache,
+	}
+
+	requestRayJob := types.NamespacedName{
+		Name:      rayJobName,
+		Namespace: testNamespace,
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: requestRayJob})
+	require.NoError(t, err)
+
+	var after v2pb.RayJob
+	require.NoError(t, r.Get(ctx, requestRayJob, &after))
+	assert.True(t, utils.IsImmutable(&after), "already-terminal RayJob must still be marked immutable even when this pass made no status change")
+}

--- a/go/components/ray/job/controller_test.go
+++ b/go/components/ray/job/controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
 	"github.com/michelangelo-ai/michelangelo/go/components/jobs/client/clientmocks"
 	jobscluster "github.com/michelangelo-ai/michelangelo/go/components/jobs/cluster"
 	jobtypes "github.com/michelangelo-ai/michelangelo/go/components/jobs/common/types"
@@ -622,6 +623,10 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {
 				assert.Equal(t, "SUCCEEDED", job.Status.JobStatus)
+				// job is re-fetched via the client after Reconcile, so this only
+				// passes if the annotation reached the API server, not just the
+				// in-memory object.
+				assert.True(t, utils.IsImmutable(job), "terminal RayJob should be marked immutable")
 			},
 		},
 		{
@@ -690,6 +695,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {
 				assert.Equal(t, "FAILED", job.Status.JobStatus)
+				assert.True(t, utils.IsImmutable(job), "terminal RayJob should be marked immutable")
 			},
 		},
 		{
@@ -758,6 +764,7 @@ func TestReconciler_Reconcile(t *testing.T) {
 			},
 			verifyConditions: func(t *testing.T, job *v2pb.RayJob) {
 				assert.Equal(t, "STOPPED", job.Status.JobStatus)
+				assert.True(t, utils.IsImmutable(job), "terminal RayJob should be marked immutable")
 			},
 		},
 		{
@@ -987,4 +994,106 @@ func TestReconciler_Reconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReconciler_Reconcile_NoOpSkipsStatusWrite verifies that a reconcile pass
+// which produces no actual status change performs no write at all. The
+// original dirty-check compared a *v2pb.RayJob to a v2pb.RayJob with
+// reflect.DeepEqual, which reports distinct types as unequal regardless of
+// content -- so status was rewritten, and a new watch event fired, on every
+// single reconcile, even when nothing changed.
+func TestReconciler_Reconcile_NoOpSkipsStatusWrite(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := runtime.NewScheme()
+	kubescheme.AddToScheme(scheme)
+	v2pb.AddToScheme(scheme)
+
+	rayJob := &v2pb.RayJob{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       rayJobName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+		Spec: v2pb.RayJobSpec{
+			Cluster: &apipb.ResourceIdentifier{
+				Name:      testClusterName,
+				Namespace: testNamespace,
+			},
+			Entrypoint: "echo Hello World",
+		},
+		Status: v2pb.RayJobStatus{
+			State:        v2pb.RAY_JOB_STATE_RUNNING,
+			JobStatus:    string(v1.JobStatusRunning),
+			DashboardUrl: "http://dashboard.example.com",
+			StatusConditions: []*apipb.Condition{
+				{
+					Type:   "Launched",
+					Status: apipb.CONDITION_STATUS_TRUE,
+				},
+			},
+		},
+	}
+	cluster := &v2pb.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testClusterName,
+			Namespace:  testNamespace,
+			Generation: 1,
+		},
+		Status: v2pb.RayClusterStatus{
+			State: v2pb.RAY_CLUSTER_STATE_READY,
+			Assignment: &v2pb.AssignmentInfo{
+				Cluster: assignedCluster,
+			},
+		},
+	}
+
+	objects := make([]client.Object, 0)
+	objects = append(objects, rayJob)
+	objects = append(objects, cluster)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithStatusSubresource(objects...).Build()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockFedClient := clientmocks.NewMockFederatedClient(mockCtrl)
+	mockCache := newMockClusterCache()
+	mockCache.addCluster(assignedCluster, &v2pb.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: assignedCluster,
+		},
+	})
+	// The federated status poll reports back exactly what is already stored,
+	// so this reconcile has nothing new to persist.
+	mockFedClient.EXPECT().GetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(&jobtypes.JobStatus{
+		Ray: &v2pb.RayJobStatus{
+			JobStatus:    string(v1.JobStatusRunning),
+			State:        v2pb.RAY_JOB_STATE_RUNNING,
+			DashboardUrl: "http://dashboard.example.com",
+		},
+	}, nil)
+
+	r := &Reconciler{
+		Client:          fakeClient,
+		federatedClient: mockFedClient,
+		clusterCache:    mockCache,
+	}
+
+	requestRayJob := types.NamespacedName{
+		Name:      rayJobName,
+		Namespace: testNamespace,
+	}
+
+	var before v2pb.RayJob
+	require.NoError(t, r.Get(ctx, requestRayJob, &before))
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: requestRayJob})
+	require.NoError(t, err)
+
+	var after v2pb.RayJob
+	require.NoError(t, r.Get(ctx, requestRayJob, &after))
+
+	// A changed resourceVersion means either Status().Update or the plain
+	// Update fired -- and neither should, since nothing actually changed.
+	assert.Equal(t, before.ResourceVersion, after.ResourceVersion, "no-op reconcile must not write the RayJob")
 }


### PR DESCRIPTION
## Problem

Part of the reconcile-storm fix. In `RayJob.Reconcile` (`go/components/ray/job/controller.go`), RayJobs rewrote their status on every reconcile, and terminal jobs never became immutable — so they were reconciled forever and the ingester never collected them.

## Fix

- **Always-dirty status check.** `originalRayJob` (a `*RayJob` from `DeepCopy`) was compared to `rayJob` (a value) via `reflect.DeepEqual`, which is unequal on type alone — so status was rewritten (firing a fresh watch event) every pass. Now compares `.Status` to `.Status`, matching the `RayCluster` controller.
- **Dropped annotation.** `utils.MarkImmutable` sets an annotation (metadata), but the block only did `Status().Update` (status subresource), so the marker never reached etcd. Now persisted with a plain `Update`.
- **Marker gated behind the dirty-check.** Once a terminal job's status settles, the dirty-check goes false and the marker was skipped forever. It now runs independently, on every reconcile while terminal-but-mutable.
- **Hardened write.** Factored into `markImmutableIfTerminal`: it re-fetches the latest object, retries on conflict, and the caller requeues if the write ultimately fails — so a conflict (from the preceding status update or a concurrent writer) no longer strands a terminal job as mutable.

Out of scope: the cluster controller's own fixes and the NotFound-on-remote case (#2006, now on main).

## Verification

- `bazel build //go/components/ray/...` and `bazel test //go/components/ray/...` pass.
- `controller_test.go`: all three terminal states assert immutability on the RayJob re-fetched from the fake client; `NoOpSkipsStatusWrite` proves no write occurs when nothing changed; `RetriesImmutableAnnotationWhenStatusUnchanged` proves a settled terminal job still becomes immutable.
- Local OSS sandbox e2e: missing-cluster job → FAILED + immutable, happy-path job → SUCCEEDED + immutable, `resourceVersion` flat after terminal (no status-write storm).
