### PR TITLE
docs(ui): document lowercase-canonical entity name convention

### DIFF
--- a/docs/contributing/dev/ui/configuration/configuration-api.md
+++ b/docs/contributing/dev/ui/configuration/configuration-api.md
@@ -46,7 +46,7 @@ See [`javascript/packages/core/config/phases`](https://github.com/michelangelo-a
 // Example: config/entities/run/run.ts
 export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'runs',
-  name: 'Runs',
+  name: 'runs',
   service: 'pipelineRun',
   state: 'active',
   views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],
@@ -54,6 +54,9 @@ export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
 ```
 
 - **id**: URL routing (`/<phase>/runs`)
+- **name**: lowercase canonical form — nav title-cases it at render time via
+  `formatEntityName`. Note this differs from phase `name` above, which is stored
+  Title Case. See [Entity Configuration Reference](./entity-configuration-reference.md#name)
 - **service**: Maps to protobuf service name
 - **views**: Supported views (list, detail)
 

--- a/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
+++ b/docs/contributing/dev/ui/configuration/entity-configuration-reference.md
@@ -13,7 +13,7 @@ Entities define data models and their properties within a phase. Each entity rep
 | Property | Type | Description | Required |
 |----------|------|-------------|----------|
 | `id` | `string` | Unique identifier within the phase, used in URL routing | ✅ Yes |
-| `name` | `string` | Display name for the entity (plural, lowercase recommended) | ✅ Yes |
+| `name` | `string` | Lowercase canonical display name (plural); title-cased at render time in nav | ✅ Yes |
 | `service` | `string` | Name of the protobuf service this entity maps to | ✅ Yes |
 | `state` | `PhaseEntityState` | Controls entity availability | ✅ Yes |
 | `views` | `ViewConfig[]` | Array of view configurations (list, detail, form) | ✅ Yes |
@@ -33,7 +33,7 @@ The `state` property controls individual entity behavior within a phase:
 // From: config/entities/run/run.ts
 export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
   id: 'runs',
-  name: 'Runs',
+  name: 'runs',
   service: 'pipelineRun',
   state: 'active',
   views: [RUN_LIST_CONFIG, RUN_DETAIL_CONFIG],
@@ -50,10 +50,25 @@ export const RUN_ENTITY_CONFIG: PhaseEntityConfig = {
 - Convention: plural, lowercase, hyphenated (e.g., `runs`, `pipelines`, `feature-groups`)
 
 ### `name`
-- Display name shown in navigation and headers
+- The **lowercase canonical** display name for the entity. Store it lowercase; casing is applied at render time, not in config
 - Recommended: plural, descriptive
-- Examples: `"Runs"`, `"Pipelines"`, `"Trained Models"`
-- Can be intentionally not pluralized for special cases (e.g., `"Feature Consistency"`)
+- Examples: `"runs"`, `"pipelines"`, `"trained models"`
+- Can be intentionally not pluralized for special cases (e.g., `"feature consistency"`)
+
+Nav chrome — breadcrumbs, left-nav, phase tabs, page H1s — renders the name through
+`formatEntityName(name, 'nav')`, which title-cases each space-separated word, so
+`'trained models'` displays as **Trained Models**. Everywhere else the lowercase value
+is itself the correct display form, which is why it reads naturally mid-sentence
+("no runs found"). Pre-casing the config value is invisible in nav — `formatEntityName`
+leaves existing capitals alone, so it's idempotent there — which is exactly why the
+mistake is easy to miss: it looks right in the tabs and breaks the sentence case
+everywhere else.
+
+:::note
+This applies to entity `name` only. Phase `name` in `config/phases/` stays Title Case
+(`'Train & Evaluate'`, `'Prepare & Analyze Data'`) — phases are not passed through
+`formatEntityName`.
+:::
 
 ### `service`
 - Maps to the root protobuf field name of the backend service
@@ -109,7 +124,7 @@ service PipelineRunService {
 // Entity config
 {
   id: 'runs',
-  name: 'Runs',
+  name: 'runs',
   service: 'pipelineRun', // ← Must match root field name
   // ...
 }


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [x] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**

Brings the UI configuration docs in line with the lowercase-canonical entity `name`
convention that #2040 established, and documents the convention itself.

- `entity-configuration-reference.md` — `name: 'Runs'` → `'runs'` in both code
  examples; property table and Examples list switched to lowercase; new paragraph
  explaining that `formatEntityName(name, 'nav')` applies Title Case at render time
  for nav chrome only; a `:::note` clarifying this does **not** apply to phase `name`.
- `configuration-api.md` — same value fix, plus a `name` bullet calling out that
  entity `name` is lowercase while the phase `name` shown directly above it on the
  same page stays Title Case.

**The stale example strings were the smaller half of this.** The `name` field's
*described semantics* were also wrong. The docs called it "Display name shown in
navigation and headers." It is now the lowercase canonical value, title-cased only
when rendered into nav chrome (breadcrumbs, left-nav, phase tabs, page H1s).
Everywhere else the lowercase form *is* the display form — which is what makes it
read correctly mid-sentence ("no runs found").

<!-- Tell your future self why have you made these changes -->
**Why?**

#2040 ("fix(core): title-case entity names in remaining nav consumers") moved nav
casing to render time and lowercased all six entity configs, but shipped with
`Documentation Changes: N/A`. That left these docs describing the previous
convention.

This is the second time these examples have gone stale in a week: #2016 corrected
them for the `Pipeline Runs` → `Runs` rename on 2026-09-03, and #2040 invalidated
that correction on 2026-09-09. Documenting the *rule* rather than only patching the
strings is the part meant to stop a third round.

The failure mode is quiet, which is why it's worth spelling out in the docs:
`formatEntityName` leaves existing capitals untouched, so it's idempotent. A
contributor who copies the old Title Case example gets something that looks correct
in the tabs and breaks sentence case everywhere else — no error, no visual cue in the
place they'd think to check.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Verified against `origin/main`:

- All six entity configs are lowercase: `deployments`, `trained models`, `pipelines`,
  `runs`, `targets`, `triggers`. Every `name` value shown in the docs now matches its
  source file.
- `formatEntityName` (`core/utils/string-utils.ts:115`) title-cases each
  space-separated word only when passed `'nav'`; its docstring states the lowercase
  canonical value is the correct display form elsewhere. Applied in `breadcrumb-bar`,
  `phase-entity-list`, `phase-entity-view` tabs, and `phase-card`.
- Phase configs confirmed **unaffected** — `config/phases/train.ts` and `data.ts` keep
  Title Case (`'Train & Evaluate'`, `'Prepare & Analyze Data'`), and
  `phase-configuration-reference.md` already documents that correctly, so it is
  untouched here.
- Swept every doc referencing `PhaseEntityConfig` / `ENTITY_CONFIG`;
  `types-and-patterns.md:57` was already correct (`Display name (plural, lowercase)`).
  No Title Case entity examples remain anywhere under `docs/`.
- Relative link and `#name` anchor in the new `configuration-api.md` bullet resolve.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None — documentation only. No code, config, or schema changes.

<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Does this PR introduce a user-facing or API change? Is user document updated? -->
**Documentation Changes**

This PR is the documentation change — two files under
`docs/contributing/dev/ui/configuration/`. No content removed.

One open question for UI owners: `formatEntityName` is now load-bearing for anyone
authoring an entity config, but it is only described in these guides. If the casing
convention shifts again, this doc is the thing that goes stale. A short doc comment
on `PhaseEntityConfig.name` pointing at the render-time rule would keep the
convention next to the type contributors actually autocomplete against.
