### PR TITLE
fix(pipelinerun): retry transient actor errors instead of failing the run

### DIFF
--- a/go/components/pipelinerun/actors/executeworkflow.go
+++ b/go/components/pipelinerun/actors/executeworkflow.go
@@ -275,7 +275,11 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 	retryErr := a.processManualRetrySpec(ctx, pipelineRun)
 	if retryErr != nil {
 		logger.Error("failed to process manual retry spec", zap.Error(retryErr))
-		return nil, retryErr
+		if pipelinerunutils.IsTerminal(retryErr) {
+			return nil, retryErr
+		}
+		return pipelinerunutils.TransientCondition(pipelineRun, ExecuteWorkflowType,
+			pipelinerunutils.ReasonManualRetryFailed, retryErr, pipelinerunutils.StartupRetryDeadline)
 	}
 
 	executeWorkflowStep := pipelinerunutils.GetStep(pipelineRun, pipelinerunutils.ExecuteWorkflowStepName)
@@ -313,11 +317,12 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 	if pipelineRun.Spec.Kill {
 		workflowTerminated, err := a.processJobTermination(ctx, pipelineRun)
 		if err != nil {
+			// A failed cancel is a transport failure, not a failed pipeline. The
+			// workflow is still live, so requeue and try again rather than marking
+			// the run FAILED while its compute keeps running.
 			logger.Error("failed to terminate workflow", zap.Error(err))
-			return &apipb.Condition{
-				Type:   ExecuteWorkflowType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("failed to terminate workflow: %w", err)
+			return pipelinerunutils.TransientCondition(pipelineRun, ExecuteWorkflowType,
+				pipelinerunutils.ReasonWorkflowTerminationFailed, err, pipelinerunutils.StartupRetryDeadline)
 		}
 		// check to see if workflow has been successfully terminated
 		if workflowTerminated {
@@ -340,26 +345,26 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 		logger.Info("deciding worker queue...")
 		err := a.apiHandler.Get(ctx, pipelineRun.Namespace, pipelineRun.Namespace, &metav1.GetOptions{}, project)
 		if err != nil {
-			logger.Warn("failed to get project, using config fallback", zap.Error(err), zap.String("projectName", pipelineRun.Namespace))
-			return &apipb.Condition{
-				Type:   ExecuteWorkflowType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("failed to fetch project %w", err)
+			logger.Error("failed to get project", zap.Error(err), zap.String("projectName", pipelineRun.Namespace))
+			if !pipelinerunutils.RetryableAPIError(err) {
+				executeWorkflowStep.Message = fmt.Sprintf("project %s not found", pipelineRun.Namespace)
+				return nil, fmt.Errorf("failed to fetch project %s: %w", pipelineRun.Namespace, err)
+			}
+			return pipelinerunutils.TransientCondition(pipelineRun, ExecuteWorkflowType,
+				pipelinerunutils.ReasonProjectFetchFailed, err, pipelinerunutils.StartupRetryDeadline)
 		}
 
 		taskList, taskListErr := a.getTaskList(project, pipelineRun)
 		if taskListErr != nil {
-			return &apipb.Condition{
-				Type:   ExecuteWorkflowType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("get workflow client config: %w", taskListErr)
+			// Resolving the worker queue reads a project annotation and static
+			// config; retrying cannot change the answer.
+			executeWorkflowStep.Message = "could not resolve the worker queue for this run"
+			return nil, fmt.Errorf("get workflow client config: %w", taskListErr)
 		}
 		if taskList == "" {
 			logger.Error("WorkflowClient TaskList is empty")
-			return &apipb.Condition{
-				Type:   ExecuteWorkflowType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("WorkflowClient TaskList is empty")
+			executeWorkflowStep.Message = "no worker queue configured for this run"
+			return nil, fmt.Errorf("WorkflowClient TaskList is empty")
 		}
 
 		workflowExecution, err := a.StartWorkflow(ctx, pipelineRun, taskList)
@@ -369,10 +374,13 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 				zap.String("operation", "start_workflow"),
 				zap.String("namespace", pipelineRun.Namespace),
 				zap.String("name", pipelineRun.Name))
-			return &apipb.Condition{
-				Type:   ExecuteWorkflowType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("start workflow for pipeline run %s/%s: %w", pipelineRun.Namespace, pipelineRun.Name, err)
+			if pipelinerunutils.IsTerminal(err) {
+				executeWorkflowStep.Message = err.Error()
+				return nil, fmt.Errorf("start workflow for pipeline run %s/%s: %w",
+					pipelineRun.Namespace, pipelineRun.Name, err)
+			}
+			return pipelinerunutils.TransientCondition(pipelineRun, ExecuteWorkflowType,
+				pipelinerunutils.ReasonWorkflowStartFailed, err, pipelinerunutils.StartupRetryDeadline)
 		}
 		executeWorkflowStep.State = v2.PIPELINE_RUN_STEP_STATE_RUNNING
 		executeWorkflowStep.StartTime = pbtypes.TimestampNow()
@@ -389,15 +397,21 @@ func (a *ExecuteWorkflowActor) Run(ctx context.Context, pipelineRun *v2.Pipeline
 	logger.Info("workflow run ID is not empty, checking workflow status")
 	workflowExecution, err := a.workflowClient.GetWorkflowExecutionInfo(ctx, pipelineRun.Status.WorkflowId, pipelineRun.Status.WorkflowRunId)
 	if err != nil {
-		return nil, fmt.Errorf("get workflow execution info for pipeline run %s/%s (workflow %s, run %s): %w",
-			pipelineRun.Namespace, pipelineRun.Name, pipelineRun.Status.WorkflowId, pipelineRun.Status.WorkflowRunId, err)
+		// The workflow exists and is the source of truth for this run's outcome, so
+		// being unable to read it says nothing about the pipeline. Retry without a
+		// deadline: a long workflow-service outage must not fail healthy runs.
+		logger.Error("failed to get workflow execution info", zap.Error(err))
+		return pipelinerunutils.TransientCondition(pipelineRun, ExecuteWorkflowType,
+			pipelinerunutils.ReasonWorkflowStatusUnavailable, err, pipelinerunutils.NoRetryDeadline)
 	}
 
 	// Query and update task-level status for all workflow states
 	taskSteps, queryErr := a.constructPipelineRunStepInfo(ctx, pipelineRun)
 	if queryErr != nil {
-		logger.Error("failed to query task progress", zap.Error(queryErr))
-		return nil, queryErr
+		// Task progress is display detail layered on the workflow status read just
+		// above. Failing to query it must not decide the run's fate, so keep the
+		// substeps already recorded and carry on to the status switch below.
+		logger.Warn("failed to query task progress, leaving substeps unchanged", zap.Error(queryErr))
 	} else if len(taskSteps) > 0 {
 		executeWorkflowStep.SubSteps = taskSteps
 	}
@@ -461,13 +475,23 @@ func (a *ExecuteWorkflowActor) processJobTermination(ctx context.Context, pipeli
 func (a *ExecuteWorkflowActor) StartWorkflow(ctx context.Context, pipelineRun *v2.PipelineRun, taskList string) (*clientInterfaces.WorkflowExecution, error) {
 	args, kwArgs, envs, err := getWorkflowInputs(pipelineRun)
 	if err != nil {
-		return nil, fmt.Errorf("get workflow inputs for pipeline run %s/%s: %w", pipelineRun.Namespace, pipelineRun.Name, err)
+		// Decoding the pipeline manifest is deterministic: a malformed manifest
+		// fails identically on every attempt.
+		return nil, pipelinerunutils.Terminalf("get workflow inputs for pipeline run %s/%s: %w",
+			pipelineRun.Namespace, pipelineRun.Name, err)
 	}
 	err = a.addTaskCacheEnv(ctx, pipelineRun, envs)
 	if err != nil {
+		if !pipelinerunutils.RetryableAPIError(err) {
+			return nil, pipelinerunutils.Terminalf("failed to add task cache env: %w", err)
+		}
 		return nil, fmt.Errorf("failed to add task cache env: %w", err)
 	}
 	pipeline := pipelineRun.Status.SourcePipeline.Pipeline
+	// TODO: the blob store reports every failure as an opaque error, so a missing
+	// tar is indistinguishable from an outage and is retried like one. Classify it
+	// as terminal once blobstore exposes a not-found - the azure client currently
+	// flattens a 404 into a formatted string with nothing wrapped.
 	tarContent, err := a.blobStore.Get(ctx, pipeline.Spec.Manifest.UniflowTar)
 	if err != nil {
 		return nil, fmt.Errorf("get tar content for pipeline %s/%s: %w", pipeline.Namespace, pipeline.Name, err)
@@ -1063,7 +1087,7 @@ func (a *ExecuteWorkflowActor) findTaskResetEventIDByActivityID(ctx context.Cont
 	}
 
 	if firstActivityScheduledEventID == 0 {
-		return 0, fmt.Errorf("could not find scheduled event for first activity %s", firstActivityID)
+		return 0, pipelinerunutils.Terminalf("could not find scheduled event for first activity %s", firstActivityID)
 	}
 
 	// Find the decision/workflow task completed event immediately before the first activity
@@ -1084,7 +1108,7 @@ func (a *ExecuteWorkflowActor) findTaskResetEventIDByActivityID(ctx context.Cont
 	}
 
 	if resetEventID == 0 {
-		return 0, fmt.Errorf("could not find safe reset boundary before first activity %s", firstActivityID)
+		return 0, pipelinerunutils.Terminalf("could not find safe reset boundary before first activity %s", firstActivityID)
 	}
 
 	logger.Info("found precise reset boundary using activity ID",

--- a/go/components/pipelinerun/actors/sourcepipeline.go
+++ b/go/components/pipelinerun/actors/sourcepipeline.go
@@ -146,30 +146,25 @@ func (a *SourcePipelineActor) Run(ctx context.Context, pipelineRun *v2.PipelineR
 		devPipeline, err := a.createPipelineFromSpec(pipelineRunSpec, pipelineRun)
 		if err != nil {
 			logger.Error("failed to create pipeline from spec", zap.Error(err))
-			return &apipb.Condition{
-				Type:   SourcePipelineType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("failed to create pipeline from spec: %w", err)
+			return nil, fmt.Errorf("failed to create pipeline from spec: %w", err)
 		}
 		pipeline = devPipeline
 	} else {
 		// Regular pipeline run - fetch from Kubernetes using pipeline reference
 		if pipelineRunSpec.GetPipeline() == nil {
-			logger.Info("pipeline run has no pipeline resource ID, setting to false")
-			return &apipb.Condition{
-				Type:   SourcePipelineType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("pipeline resource ID is nil")
+			logger.Error("pipeline run has no pipeline resource ID")
+			return nil, fmt.Errorf("pipeline resource ID is nil")
 		}
 
 		pipelineResourceID := pipelineRunSpec.GetPipeline()
 		err := a.apiHandler.Get(ctx, pipelineRun.Namespace, pipelineResourceID.GetName(), &metav1.GetOptions{}, pipeline)
 		if err != nil {
 			logger.Error("failed to get pipeline", zap.Error(err))
-			return &apipb.Condition{
-				Type:   SourcePipelineType,
-				Status: apipb.CONDITION_STATUS_FALSE,
-			}, fmt.Errorf("failed to get pipeline: %w", err)
+			if !pipelinerunutils.RetryableAPIError(err) {
+				return nil, fmt.Errorf("failed to get pipeline: %w", err)
+			}
+			return pipelinerunutils.TransientCondition(pipelineRun, SourcePipelineType,
+				pipelinerunutils.ReasonPipelineFetchFailed, err, pipelinerunutils.StartupRetryDeadline)
 		}
 
 		pipeline.ObjectMeta = metav1.ObjectMeta{

--- a/go/components/pipelinerun/actors/utils/BUILD.bazel
+++ b/go/components/pipelinerun/actors/utils/BUILD.bazel
@@ -1,14 +1,33 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["utils.go"],
+    srcs = [
+        "conditions.go",
+        "utils.go",
+    ],
     importpath = "github.com/michelangelo-ai/michelangelo/go/components/pipelinerun/actors/utils",
     visibility = ["//visibility:public"],
     deps = [
         "//go/api:go_default_library",
+        "//go/api/utils:go_default_library",
+        "//go/base/conditions/utils:go_default_library",
         "//proto/api:go_default_library",
         "//proto/api/v2:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["conditions_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/api:go_default_library",
+        "//proto/api/v2:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
     ],
 )

--- a/go/components/pipelinerun/actors/utils/conditions.go
+++ b/go/components/pipelinerun/actors/utils/conditions.go
@@ -1,0 +1,126 @@
+package pipelinerunutils
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/michelangelo-ai/michelangelo/go/api/utils"
+	conditionUtils "github.com/michelangelo-ai/michelangelo/go/base/conditions/utils"
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
+	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+// Actors signal failure to the condition engine in one of two ways.
+//
+// A non-retryable failure is returned as an error. The engine treats any error
+// as critical and terminal, and the controller marks the run FAILED. Because the
+// engine returns before persisting the condition, terminal paths should record
+// their explanation on the step (step.Message) rather than on the condition.
+//
+// A retryable failure is returned as an UNKNOWN condition with a nil error. The
+// engine leaves the resource unsatisfied and requeues it, so the run keeps its
+// current state instead of failing. This matters because a pipeline run must not
+// be failed by an infrastructure blip: a genuine pipeline failure reaches the
+// controller as a workflow execution status (Failed, TimedOut), never as a
+// client error, so an error talking to the workflow service is by construction
+// transport-level and worth retrying.
+
+const (
+	// StartupRetryDeadline bounds how long a transient failure may keep a run
+	// requeueing before it is given up on as terminal. It applies to the paths
+	// that run before the workflow exists - fetching the project, resolving the
+	// task list, starting the workflow - where nothing else is tracking the run.
+	//
+	// Reads against an already-running workflow are deliberately unbounded (see
+	// NoRetryDeadline): the workflow is the source of truth for those runs, and a
+	// long workflow-service outage must not fail pipelines that are still healthy.
+	//
+	// TODO: make this configurable alongside the condition engine's requeue
+	// period, which is likewise hardcoded today.
+	StartupRetryDeadline = 30 * time.Minute
+
+	// NoRetryDeadline disables the deadline, retrying for as long as the failure
+	// persists.
+	NoRetryDeadline time.Duration = 0
+)
+
+// Reasons for transient conditions. These are compared across reconciles to
+// decide whether a failure is the same one we saw last time, so they must be
+// stable identifiers and never interpolate error text.
+const (
+	ReasonManualRetryFailed         = "ManualRetryFailed"
+	ReasonWorkflowTerminationFailed = "WorkflowTerminationFailed"
+	ReasonProjectFetchFailed        = "ProjectFetchFailed"
+	ReasonWorkflowStartFailed       = "WorkflowStartFailed"
+	ReasonWorkflowStatusUnavailable = "WorkflowStatusUnavailable"
+	ReasonPipelineFetchFailed       = "PipelineFetchFailed"
+)
+
+// TransientCondition builds the UNKNOWN condition an actor returns for a
+// retryable failure, or an error once the failure has outlasted the deadline.
+//
+// When the same failure repeats, the previously persisted condition is returned
+// unchanged. That is deliberate: the controller only writes status when it
+// differs from what it read, and a status write feeds the controller's own watch,
+// which would re-reconcile immediately and defeat the engine's requeue delay. A
+// condition carrying a counter or a varying message would therefore spin rather
+// than back off, so elapsed time is measured from the timestamp on the first
+// occurrence instead.
+//
+// Pass NoRetryDeadline to retry indefinitely.
+func TransientCondition(
+	pipelineRun *v2.PipelineRun,
+	conditionType string,
+	reason string,
+	err error,
+	deadline time.Duration,
+) (*apipb.Condition, error) {
+	now := time.Now()
+	existing := conditionUtils.GetCondition(conditionType, pipelineRun.Status.Conditions)
+
+	if existing != nil && existing.Status == apipb.CONDITION_STATUS_UNKNOWN && existing.Reason == reason {
+		if deadline > NoRetryDeadline && existing.LastUpdatedTimestamp > 0 {
+			if elapsed := now.Sub(time.Unix(existing.LastUpdatedTimestamp, 0)); elapsed > deadline {
+				return nil, fmt.Errorf("%s: still failing after %s, giving up: %w",
+					reason, elapsed.Truncate(time.Second), err)
+			}
+		}
+		return existing, nil
+	}
+
+	return &apipb.Condition{
+		Type:                 conditionType,
+		Status:               apipb.CONDITION_STATUS_UNKNOWN,
+		Reason:               reason,
+		Message:              err.Error(),
+		LastUpdatedTimestamp: now.Unix(),
+	}, nil
+}
+
+// TerminalError marks a failure that retrying cannot resolve. Helpers that mix
+// retryable and non-retryable failures wrap the latter so their callers can tell
+// the two apart without inspecting error strings.
+type TerminalError struct{ Err error }
+
+func (e *TerminalError) Error() string { return e.Err.Error() }
+
+func (e *TerminalError) Unwrap() error { return e.Err }
+
+// Terminalf builds a TerminalError from a format string.
+func Terminalf(format string, args ...interface{}) error {
+	return &TerminalError{Err: fmt.Errorf(format, args...)}
+}
+
+// IsTerminal reports whether err was marked non-retryable with Terminalf.
+func IsTerminal(err error) bool {
+	var terminal *TerminalError
+	return errors.As(err, &terminal)
+}
+
+// RetryableAPIError reports whether an error from a Kubernetes or gRPC read is
+// worth retrying. A NotFound means the referenced resource genuinely does not
+// exist, and retrying cannot conjure it.
+func RetryableAPIError(err error) bool {
+	return !utils.IsNotFoundError(err)
+}

--- a/go/components/pipelinerun/actors/utils/conditions_test.go
+++ b/go/components/pipelinerun/actors/utils/conditions_test.go
@@ -1,0 +1,128 @@
+package pipelinerunutils
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	apipb "github.com/michelangelo-ai/michelangelo/proto-go/api"
+	v2 "github.com/michelangelo-ai/michelangelo/proto-go/api/v2"
+)
+
+const testConditionType = "ExecuteWorkflow"
+
+func runWithConditions(conditions ...*apipb.Condition) *v2.PipelineRun {
+	return &v2.PipelineRun{Status: v2.PipelineRunStatus{Conditions: conditions}}
+}
+
+func TestTransientConditionStartsTheClockOnFirstFailure(t *testing.T) {
+	run := runWithConditions()
+
+	condition, err := TransientCondition(run, testConditionType,
+		ReasonWorkflowStatusUnavailable, errors.New("service unavailable"), StartupRetryDeadline)
+
+	require.NoError(t, err)
+	require.Equal(t, apipb.CONDITION_STATUS_UNKNOWN, condition.Status)
+	require.Equal(t, ReasonWorkflowStatusUnavailable, condition.Reason)
+	require.Equal(t, "service unavailable", condition.Message)
+	require.NotZero(t, condition.LastUpdatedTimestamp)
+}
+
+// The controller only writes status when it differs from what it read, and a
+// status write feeds its own watch. Returning the stored condition untouched is
+// what keeps a retry from re-triggering reconcile immediately.
+func TestTransientConditionIsUnchangedWhileTheSameFailureRepeats(t *testing.T) {
+	firstSeen := time.Now().Add(-time.Minute).Unix()
+	existing := &apipb.Condition{
+		Type:                 testConditionType,
+		Status:               apipb.CONDITION_STATUS_UNKNOWN,
+		Reason:               ReasonWorkflowStatusUnavailable,
+		Message:              "service unavailable",
+		LastUpdatedTimestamp: firstSeen,
+	}
+	run := runWithConditions(existing)
+
+	condition, err := TransientCondition(run, testConditionType,
+		ReasonWorkflowStatusUnavailable, errors.New("service unavailable (attempt 2)"), StartupRetryDeadline)
+
+	require.NoError(t, err)
+	require.Equal(t, firstSeen, condition.LastUpdatedTimestamp, "clock must not restart")
+	require.Equal(t, "service unavailable", condition.Message, "message must stay stable")
+	require.Equal(t, existing, condition)
+}
+
+func TestTransientConditionGivesUpOnceTheDeadlinePasses(t *testing.T) {
+	run := runWithConditions(&apipb.Condition{
+		Type:                 testConditionType,
+		Status:               apipb.CONDITION_STATUS_UNKNOWN,
+		Reason:               ReasonProjectFetchFailed,
+		LastUpdatedTimestamp: time.Now().Add(-2 * StartupRetryDeadline).Unix(),
+	})
+
+	condition, err := TransientCondition(run, testConditionType,
+		ReasonProjectFetchFailed, errors.New("api server down"), StartupRetryDeadline)
+
+	require.Nil(t, condition)
+	require.ErrorContains(t, err, "giving up")
+	require.ErrorContains(t, err, "api server down")
+}
+
+func TestTransientConditionWithoutDeadlineRetriesForever(t *testing.T) {
+	run := runWithConditions(&apipb.Condition{
+		Type:                 testConditionType,
+		Status:               apipb.CONDITION_STATUS_UNKNOWN,
+		Reason:               ReasonWorkflowStatusUnavailable,
+		LastUpdatedTimestamp: time.Now().Add(-30 * 24 * time.Hour).Unix(),
+	})
+
+	condition, err := TransientCondition(run, testConditionType,
+		ReasonWorkflowStatusUnavailable, errors.New("still down"), NoRetryDeadline)
+
+	require.NoError(t, err)
+	require.Equal(t, apipb.CONDITION_STATUS_UNKNOWN, condition.Status)
+}
+
+// A different failure is a different clock: an old unrelated condition must not
+// make a brand new problem look like it has already exhausted its deadline.
+func TestTransientConditionRestartsTheClockForADifferentFailure(t *testing.T) {
+	stale := time.Now().Add(-2 * StartupRetryDeadline).Unix()
+	run := runWithConditions(&apipb.Condition{
+		Type:                 testConditionType,
+		Status:               apipb.CONDITION_STATUS_UNKNOWN,
+		Reason:               ReasonProjectFetchFailed,
+		LastUpdatedTimestamp: stale,
+	})
+
+	condition, err := TransientCondition(run, testConditionType,
+		ReasonWorkflowStartFailed, errors.New("cadence unreachable"), StartupRetryDeadline)
+
+	require.NoError(t, err)
+	require.Equal(t, ReasonWorkflowStartFailed, condition.Reason)
+	require.Greater(t, condition.LastUpdatedTimestamp, stale)
+}
+
+func TestIsTerminal(t *testing.T) {
+	require.True(t, IsTerminal(Terminalf("malformed manifest")))
+	require.True(t, IsTerminal(fmt.Errorf("wrapped: %w", Terminalf("malformed manifest"))))
+	require.False(t, IsTerminal(errors.New("connection refused")))
+	require.False(t, IsTerminal(nil))
+}
+
+func TestRetryableAPIError(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "projects"}, "missing")
+	require.False(t, RetryableAPIError(notFound))
+
+	require.True(t, RetryableAPIError(apierrors.NewTimeoutError("slow", 1)))
+	require.True(t, RetryableAPIError(apierrors.NewTooManyRequestsError("throttled")))
+	require.True(t, RetryableAPIError(errors.New("connection refused")))
+	require.True(t, RetryableAPIError(apierrors.NewServiceUnavailable("down")))
+
+	// Sanity: the helper is only meaningful for real API errors.
+	require.True(t, RetryableAPIError(&apierrors.StatusError{ErrStatus: metav1.Status{Code: 500}}))
+}

--- a/go/components/pipelinerun/actors/utils/utils.go
+++ b/go/components/pipelinerun/actors/utils/utils.go
@@ -68,8 +68,8 @@ func GetPipelineRun(ctx context.Context, pipelineRunID *apipb.ResourceIdentifier
 
 	err := apiHandler.Get(ctx, pipelineRunID.Namespace, pipelineRunID.Name, &metav1.GetOptions{}, pipelineRun)
 	if err != nil {
-		return fmt.Errorf("Failed to get PipelineRun namespace: %s, name: %s",
-			pipelineRunID.Namespace, pipelineRunID.Name)
+		return fmt.Errorf("failed to get PipelineRun namespace: %s, name: %s: %w",
+			pipelineRunID.Namespace, pipelineRunID.Name, err)
 	}
 	return nil
 }

--- a/go/components/pipelinerun/controller_test.go
+++ b/go/components/pipelinerun/controller_test.go
@@ -628,7 +628,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		{
-			name: "error getting workflow execution info",
+			name: "transient error getting workflow execution info requeues instead of failing",
 			initialObjects: []client.Object{
 				&v2.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
@@ -712,7 +712,9 @@ func TestReconcile(t *testing.T) {
 				// SourcePipeline.Retrieve() returns TRUE
 				// ImageBuild.Retrieve() returns TRUE
 				// ExecuteWorkflow.Retrieve() returns FALSE (workflow is running)
-				// ExecuteWorkflow.Run() tries to query workflow but gets an error; this is terminal
+				// ExecuteWorkflow.Run() cannot reach the workflow service. The workflow
+				// itself is the source of truth for this run, so the failure is
+				// transport-level: the run stays RUNNING and is requeued.
 				mockWorkflowClient.EXPECT().GetWorkflowExecutionInfo(
 					gomock.Any(),
 					"test-workflow-id",
@@ -721,8 +723,8 @@ func TestReconcile(t *testing.T) {
 			},
 			errMsg: "",
 			expectedResult: ctrl.Result{
-				Requeue:      false,
-				RequeueAfter: 0,
+				Requeue:      true,
+				RequeueAfter: 10 * time.Second,
 			},
 			expectedConditions: []*apipb.Condition{
 				{
@@ -734,12 +736,14 @@ func TestReconcile(t *testing.T) {
 					Status: apipb.CONDITION_STATUS_TRUE,
 				},
 				{
-					Type:   actors.ExecuteWorkflowType,
-					Status: apipb.CONDITION_STATUS_UNKNOWN,
+					Type:    actors.ExecuteWorkflowType,
+					Status:  apipb.CONDITION_STATUS_UNKNOWN,
+					Reason:  pipelinerunutils.ReasonWorkflowStatusUnavailable,
+					Message: "workflow service unavailable",
 				},
 			},
 			expectedPipelineRunStatus: v2.PipelineRunStatus{
-				State:         v2.PIPELINE_RUN_STATE_FAILED,
+				State:         v2.PIPELINE_RUN_STATE_RUNNING,
 				WorkflowId:    "test-workflow-id",
 				WorkflowRunId: "test-run-id",
 			},
@@ -754,7 +758,7 @@ func TestReconcile(t *testing.T) {
 				},
 				{
 					Name:  pipelinerunutils.ExecuteWorkflowStepName,
-					State: v2.PIPELINE_RUN_STEP_STATE_RUNNING, // Remains RUNNING from initial status since error happens before step update
+					State: v2.PIPELINE_RUN_STEP_STATE_RUNNING, // Untouched: the transient read failure leaves the step alone
 				},
 			},
 		},
@@ -788,6 +792,11 @@ func TestReconcile(t *testing.T) {
 				require.Contains(t, err.Error(), testCase.errMsg)
 			} else {
 				require.NoError(t, err)
+			}
+			for _, condition := range pipelineRun.Status.Conditions {
+				// Transient conditions stamp a wall-clock timestamp used to age out
+				// retries; the cases assert on type, status, reason and message.
+				condition.LastUpdatedTimestamp = 0
 			}
 			require.Equal(t, testCase.expectedConditions, pipelineRun.Status.Conditions)
 			require.Equal(t, testCase.expectedPipelineRunStatus.State, pipelineRun.Status.State)


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

**What changed?**

PipelineRun actors now distinguish retryable failures from terminal ones:

- **terminal** — return an error (bad spec, pipeline genuinely absent, workflow actually failed)
- **retryable** — return a `CONDITION_STATUS_UNKNOWN` condition with a `nil` error, so the engine requeues after 10s

New helper `go/components/pipelinerun/actors/utils/conditions.go`:

| symbol | purpose |
|---|---|
| `TransientCondition(...)` | builds the UNKNOWN condition and enforces the retry deadline |
| `StartupRetryDeadline` / `NoRetryDeadline` | 30m, and 0 for unbounded |
| `TerminalError` / `Terminalf` / `IsTerminal` | mark an error non-retryable so it passes straight through |
| `RetryableAPIError` | everything except NotFound |

Retries are bounded by a **deadline, not a counter**. A counter would mutate status on every attempt, and that write wakes the controller's own watch — so it would reconcile immediately and bypass the 10s backoff, spinning at full speed. Instead the first failure stamps `LastUpdatedTimestamp` and every repeat returns the stored condition byte-identical, which lets `updatePipelineRunStatus`'s `reflect.DeepEqual` gate (`controller.go:483`) skip the write entirely. Past the deadline it converts to a real error.

Reclassifies 8 error sites in `executeworkflow.go` and 3 in `sourcepipeline.go`. Two behavior notes worth a reviewer's eye:

- `GetWorkflowExecutionInfo` retries **unbounded** (`NoRetryDeadline`) — Cadence being unreachable shouldn't kill a run that is already executing.
- `constructPipelineRunStepInfo` is downgraded from fatal to warn-and-continue.

`GetPipelineRun` now wraps with `%w` so `IsNotFoundError` works through it.

**Why?**

Any error an actor returns is treated by the condition engine as critical and terminal — `defaultengine.go:52-63` returns `Requeue: false, IsTerminal: true` and swallows the error. So a momentary blip talking to Cadence permanently fails a run that was healthy and would have recovered on the next reconcile.

This is a regression: before #509 (`81cf25a2`) the engine returned `defaultResult, err`, which was non-terminal with a 10s requeue. `pipelinerun/controller.go` is byte-identical across that commit.

Per the discussion with @ghosharitra: the engine is a generic interface shared by every controller and shouldn't hardcode error semantics — classifying retryable errors is the controller's job. **Nothing under `go/base/conditions/` is touched here.**

**How did you test it?**

Unit — 6 new tests in `conditions_test.go` covering: clock starts on first failure; the condition stays byte-identical while the same failure repeats (asserting both timestamp and message stability, since that's what the `DeepEqual` gate depends on); gives up past the deadline; unbounded with `NoRetryDeadline`; clock restarts for a different reason; plus both predicates. `controller_test.go` now asserts the transient case requeues and stays `RUNNING` instead of failing. All 6 `//go/components/pipelinerun/...` targets pass.

Sandbox, k3d with a locally built controllermgr:

- **Before** — 270ms from creation to eviction, with a stack trace on the diagnosed path.
- **After** — run stays `RUNNING`, condition timestamp frozen at `1788305715` across retries (confirming no spurious status writes), retries at exactly 10.00s intervals.
- Survived a deliberate 96s Cadence outage, then resolved terminal correctly once the workflow genuinely failed — so the fix doesn't mask real failures.

**Potential risks**

The unbounded retry on `GetWorkflowExecutionInfo` is deliberate but is the main thing to scrutinize: a run whose workflow is permanently unreachable will requeue every 10s indefinitely rather than failing. That's the intended trade (a stuck run is recoverable; a wrongly-failed one isn't), and the 10s floor bounds the load, but it is a behavior change.

Beyond that the blast radius is limited to PipelineRun actors — no engine, controller, proto, or API changes. Failures that were terminal before and should stay terminal still return errors.

**Breaking Changes**

- [x] No breaking changes

**Release notes**

Transient errors during PipelineRun reconciliation (e.g. a brief Cadence outage) now retry instead of permanently failing the run. Fixes a regression introduced in #509.

**Documentation Changes**

None. The retry semantics are documented in the package doc comment on `conditions.go`.

---

**Follow-up (not in this PR):** deployment and inferenceserver have the same defect in worse shape — 84 `GenerateFalseCondition` calls against 5 `GenerateUnknownCondition`, and FALSE is terminal in the engine too (`defaultengine.go:76-95`), so most of their transient failures kill the rollout. Both meet the preconditions to reuse this helper: they store `[]*apipb.Condition` in `Status.Conditions` and diff-gate their status writes (`deployment/controller.go:179`, `inferenceserver/controller.go:221`). Promoting `TransientCondition` to `go/base/conditions/utils` is a one-parameter change (take the condition slice instead of `*v2.PipelineRun`), but I'd rather do it once deployment's sites are triaged and can confirm the signature fits, than ship a shared API with one consumer.

TriggerRun **cannot** use it — `TriggerRunStatus` has no `Conditions` field, no plugin, no engine; it has its own `cenkalti/backoff` in `util.go:247-275`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
