### PR TITLE
test(core): add getCall to createQueryMockRouter

### DIFF
--- a/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
+++ b/javascript/packages/core/config/entities/deployment/__tests__/deployment-page.test.tsx
@@ -25,6 +25,7 @@ import {
 import { getSnackbarProviderWrapper } from '#core/test/wrappers/get-snackbar-provider-wrapper';
 
 import type { ActionConfigSchema, Data } from '#core/components/actions/types';
+import type { DeploymentUpdateInput } from '#core/config/entities/deployment/types';
 
 describe('Deployment list page', () => {
   it('renders the Deployments tab', () => {
@@ -448,10 +449,6 @@ describe('Deployment retire action', () => {
     });
   }
 
-  function findUpdateDeploymentCall(request: ReturnType<typeof createQueryMockRouter>) {
-    return vi.mocked(request).mock.calls.find(([name]) => name === 'UpdateDeployment');
-  }
-
   it('confirms the retire in a dialog, submits the spec with desiredRevision removed, and toasts', async () => {
     const user = userEvent.setup();
     const request = createQueryMockRouter({
@@ -479,12 +476,10 @@ describe('Deployment retire action', () => {
 
     await user.click(within(dialog).getByRole('button', { name: 'Yes, retire' }));
 
-    await waitFor(() => expect(findUpdateDeploymentCall(request)).toBeDefined());
+    await waitFor(() => expect(request.getCall('UpdateDeployment')).toBeDefined());
 
-    const payload = findUpdateDeploymentCall(request)?.[1] as {
-      metadata: { name: string };
-      spec: { desiredRevision?: unknown; target?: unknown };
-    };
+    // cast: recorded call args are `unknown`; DeploymentUpdateInput is what this test's request actually sends
+    const payload = request.getCall('UpdateDeployment')!.args as DeploymentUpdateInput;
     // The absent desiredRevision is what tells the backend to run cleanup; the rest of
     // the spec must be sent through intact.
     expect(payload.spec.desiredRevision).toBeUndefined();
@@ -567,6 +562,6 @@ describe('Deployment retire action', () => {
     const dialog = await openRetireDialog(user);
     await user.click(within(dialog).getByRole('button', { name: 'Yes, retire' }));
 
-    await waitFor(() => expect(findUpdateDeploymentCall(request)).toBeDefined());
+    await waitFor(() => expect(request.getCall('UpdateDeployment')).toBeDefined());
   });
 });

--- a/javascript/packages/core/config/entities/deployment/types.ts
+++ b/javascript/packages/core/config/entities/deployment/types.ts
@@ -23,6 +23,11 @@ export type DeploymentCreateInput = {
   };
 };
 
+export type DeploymentUpdateInput = {
+  metadata: { name: string };
+  spec: { desiredRevision?: ResourceRef; target?: { case?: string; value?: ResourceRef } };
+};
+
 export type InferenceServerListResult = {
   inferenceServerList: {
     items: Array<{ metadata: { name: string } }>;

--- a/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
+++ b/javascript/packages/core/config/entities/pipeline/__tests__/create-pipeline-run-form.test.tsx
@@ -624,12 +624,15 @@ describe('CreatePipelineRunForm', () => {
       // Captures the payload so the assertion can check for the *absence* of a key,
       // which call matchers express poorly.
       const submitted: PipelineRun[] = [];
-      const request: typeof router = (queryName, args, headers) => {
-        if (queryName === 'CreatePipelineRun') {
-          submitted.push(args as PipelineRun);
-        }
-        return router(queryName, args, headers);
-      };
+      const request: typeof router = Object.assign(
+        (queryName: string, args: object, headers?: Record<string, string>) => {
+          if (queryName === 'CreatePipelineRun') {
+            submitted.push(args as PipelineRun);
+          }
+          return router(queryName, args, headers);
+        },
+        { getCall: router.getCall }
+      );
 
       renderForm(request);
 

--- a/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
+++ b/javascript/packages/core/test/wrappers/get-service-provider-wrapper.tsx
@@ -101,8 +101,14 @@ export function createServiceProviderTestContext(serviceProvider: Partial<Servic
  */
 export function createQueryMockRouter(
   responses: Record<string, object | Error>
-): ServiceContextType['request'] {
-  return vi.fn((queryName: string, args: object, _headers?: Record<string, string>) => {
+): ServiceContextType['request'] & {
+  getCall: (
+    queryName: string
+  ) =>
+    | { queryName: string; args: unknown; headers: Record<string, string> | undefined }
+    | undefined;
+} {
+  const mock = vi.fn((queryName: string, args: object, _headers?: Record<string, string>) => {
     if (args) {
       for (const [responseKey, response] of Object.entries(responses)) {
         if (isEqual(parseArgsFromKey(responseKey), { queryName, args })) {
@@ -118,6 +124,16 @@ export function createQueryMockRouter(
     }
 
     return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  });
+
+  return Object.assign(mock, {
+    getCall: (queryName: string) => {
+      const call = mock.mock.calls.find(([name]) => name === queryName);
+      if (!call) return undefined;
+
+      const [name, args, headers] = call;
+      return { queryName: name, args, headers };
+    },
   });
 }
 


### PR DESCRIPTION
Test files that needed to assert on a specific RPC call kept reinventing the same wheel: a small local helper that walks the mock's call history looking for a matching query name. Every new test that needed this ended up writing its own copy, with only the query name changed. That's the kind of duplication that's easy to miss in review and easy to get subtly wrong (mismatched argument index, wrong comparison), so this attaches the lookup directly to the mock router itself. Any test can now just ask the mock which calls it received for a given query, instead of carrying its own bespoke wrapper.

One test file builds its own thin wrapper around the mock router to intercept and capture a submitted payload before delegating to the real router. Because the router's return type now carries the extra lookup method, a plain function standing in for it no longer structurally matches — TypeScript only lets that slide when you're passing the augmented object through untouched. That wrapper had to explicitly forward the lookup method alongside its own logic to keep the types honest. It's a small tax, but a deliberate one: the alternative was loosening the type in a way that would make the augmentation easy to silently drop elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)