### PR TITLE
feat(ui): Add info tab for pipeline run detail page

### DIFF
--- a/javascript/packages/core/config/entities/run/__tests__/run-page.test.tsx
+++ b/javascript/packages/core/config/entities/run/__tests__/run-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 
 import { TRAIN_PHASE } from '#core/config/phases/train';
 import { EntityDetailRoute } from '#core/router/entity-detail-route';
@@ -38,6 +38,18 @@ describe('Run detail page', () => {
       ...overrides,
     });
 
+    /** The JSON editor rendered inside the Box whose title is `title`. */
+    const findEditorTitled = (title: string) => {
+      let node: HTMLElement | null = screen.getByText(title);
+      while (node && !node.querySelector('[role="textbox"]')) {
+        node = node.parentElement;
+      }
+      if (!node) {
+        throw new Error(`no editor found under the "${title}" box`);
+      }
+      return within(node).getByRole('textbox');
+    };
+
     it('renders the workflow log link, status indicators, and environment', async () => {
       render(
         <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
@@ -61,6 +73,130 @@ describe('Run detail page', () => {
       // Local-timezone rendering: fix the date, leave time-of-day and zone name open.
       expect(timestamp.value).toMatch(/^2023\/11\/1[45] \d{2}:\d{2}:\d{2} \(.+\)$/);
       expect(screen.getByLabelText('Environment')).toHaveValue('development');
+      // Manual run: no parameter-id label, so the field renders empty.
+      expect(screen.getByLabelText('Parameter ID')).toHaveValue('');
+      // Successful run with no manifest snapshot or input: the conditional blocks stay hidden.
+      expect(screen.queryByText('Message')).not.toBeInTheDocument();
+      expect(screen.queryByText('Content')).not.toBeInTheDocument();
+      expect(screen.queryByText('Input')).not.toBeInTheDocument();
+    });
+
+    it('shows the error message only for a run that failed with one', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/train/runs/run-1/information',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetPipelineRun: {
+                pipelineRun: buildRun({
+                  status: {
+                    state: 5,
+                    steps: [],
+                    errorMessage: 'Task train failed:\nOOMKilled',
+                  },
+                }),
+              },
+            }),
+          }),
+        ])
+      );
+
+      expect(await screen.findByText('Message')).toBeInTheDocument();
+      expect(screen.getByLabelText('Error message')).toHaveValue('Task train failed:\nOOMKilled');
+    });
+
+    it('prefers the scheduled execution timestamp label over creation time', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/train/runs/run-1/information',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetPipelineRun: {
+                pipelineRun: buildRun({
+                  metadata: {
+                    name: 'run-1',
+                    creationTimestamp: { seconds: '1700000000' },
+                    labels: {
+                      'michelangelo/environment': 'production',
+                      // 2023-07-22T05:46:40Z — a backfill slot well before the object was created.
+                      'pipelinerun.michelangelo/execution-timestamp': '1690004800',
+                      'pipelinerun.michelangelo/parameter-id': 'daily-01',
+                    },
+                  },
+                }),
+              },
+            }),
+          }),
+        ])
+      );
+
+      const timestamp = await screen.findByLabelText<HTMLInputElement>('Execution Timestamp');
+      // Local-timezone rendering: fix the date, leave time-of-day and zone name open.
+      expect(timestamp.value).toMatch(/^2023\/07\/2[12] \d{2}:\d{2}:\d{2} \(.+\)$/);
+      expect(screen.getByLabelText('Parameter ID')).toHaveValue('daily-01');
+    });
+
+    it('renders the manifest content and run input as read-only JSON', async () => {
+      render(
+        <EntityDetailRoute phases={{ train: TRAIN_PHASE }} />,
+        buildWrapper([
+          getErrorProviderWrapper(),
+          getRouterWrapper({
+            location: '/myproject/train/runs/run-1/information',
+          }),
+          getServiceProviderWrapper({
+            request: createQueryMockRouter({
+              GetPipelineRun: {
+                pipelineRun: buildRun({
+                  spec: {
+                    actor: { name: 'jsmith' },
+                    pipeline: { name: 'prediction-pipeline' },
+                    // Raw protobuf Struct, as the rpc layer delivers `spec.input`.
+                    input: {
+                      fields: {
+                        learning_rate: { numberValue: 0.01 },
+                        dataset: { stringValue: 'boston' },
+                      },
+                    },
+                  },
+                  status: {
+                    state: 3,
+                    steps: [],
+                    sourcePipeline: {
+                      pipeline: {
+                        spec: {
+                          manifest: {
+                            type: 1,
+                            content: {
+                              typeUrl: 'type.googleapis.com/michelangelo.PredictionPipelineConf',
+                              value: { meta: { workflow_version: 'v2' } },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                }),
+              },
+            }),
+          }),
+        ])
+      );
+
+      await screen.findByText('Content');
+      // The CodeMirror editor exposes its content as a readonly textbox.
+      expect(findEditorTitled('Content')).toHaveTextContent('"workflow_version": "v2"');
+      const inputEditor = findEditorTitled('Input');
+      expect(inputEditor).toHaveTextContent('"learning_rate": 0.01');
+      expect(inputEditor).toHaveTextContent('"dataset": "boston"');
     });
 
     it('links a resumed run back to its source run', async () => {

--- a/javascript/packages/core/config/entities/run/run-configuration-page.tsx
+++ b/javascript/packages/core/config/entities/run/run-configuration-page.tsx
@@ -7,6 +7,7 @@ import { CircleExclamationMark } from '#core/components/illustrations/circle-exc
 import { CircleExclamationMarkKind } from '#core/components/illustrations/circle-exclamation-mark/types';
 import { Signpost } from '#core/components/signpost/signpost';
 import { TextEditor } from '#core/components/text-editor/text-editor';
+import { getRunManifestContent } from './shared';
 
 import type { PipelineRun } from './types';
 
@@ -16,12 +17,7 @@ export function RunConfigurationPage({ data, isLoading }: { data?: object; isLoa
   // cast: custom detail pages receive the entity as a plain object; narrowing to the
   // expected proto shape for property access; see #1425
   const run = data as PipelineRun | undefined;
-  const sourcePipeline = run?.status?.sourcePipeline;
-  const manifest =
-    sourcePipeline?.pipeline?.spec?.manifest ??
-    sourcePipeline?.draftPipeline?.spec?.manifest ??
-    run?.spec?.pipelineSpec?.manifest;
-  const config = manifest?.content?.value;
+  const config = getRunManifestContent(run);
 
   if (isLoading) {
     return <Skeleton animation height="400px" width="100%" />;

--- a/javascript/packages/core/config/entities/run/run-info-page.tsx
+++ b/javascript/packages/core/config/entities/run/run-info-page.tsx
@@ -4,14 +4,18 @@ import { HeadingSmall } from 'baseui/typography';
 
 import { Box } from '#core/components/box/box';
 import { StringField } from '#core/components/form/fields/string/string-field';
+import { TextareaField } from '#core/components/form/fields/textarea/textarea-field';
 import { Form } from '#core/components/form/form';
 import { LinksBox } from '#core/components/links-box/links-box';
+import { TextEditor } from '#core/components/text-editor/text-editor';
 import { useStudioParams } from '#core/hooks/routing/use-studio-params/use-studio-params';
 import { TimeZone } from '#core/types/time-types';
+import { decodeStruct, isStruct } from '#core/utils/proto/struct-utils';
 import { timestampToString } from '#core/utils/time-utils';
+import { getRunManifestContent } from './shared';
 import { PipelineRunState, TERMINAL_RUN_STATES } from './types';
 
-import type { PipelineRunStepInfo, PipelineRunSummary } from './types';
+import type { PipelineRunStepInfo, PipelineRunSummary, ReadOnlyField } from './types';
 
 /**
  * Step name assigned by the backend to the wrapper step that executes the
@@ -23,6 +27,17 @@ const EXECUTE_WORKFLOW_STEP_NAME = 'Execute Workflow';
 
 /** Label key stamped on every run by the create/update API hooks. */
 const ENVIRONMENT_LABEL = 'michelangelo/environment';
+
+/**
+ * Logical execution time of a scheduled run, stamped by the trigger workflow as unix
+ * seconds. Manual runs carry no such label.
+ */
+const EXECUTION_TIMESTAMP_LABEL = 'pipelinerun.michelangelo/execution-timestamp';
+
+/**
+ * Identifies which entry of the pipeline's `params_map` a scheduled run executed with.
+ */
+const PARAMETER_ID_LABEL = 'pipelinerun.michelangelo/parameter-id';
 
 export function RunInfoPage({ data, isLoading }: { data?: object; isLoading: boolean }) {
   const [css, theme] = useStyletron();
@@ -44,35 +59,44 @@ export function RunInfoPage({ data, isLoading }: { data?: object; isLoading: boo
     },
   ];
 
-  const statusFields = [
+  const errorMessage = run?.status?.errorMessage;
+  const manifestContent = getRunManifestContent(run);
+  const input = decodeRunInput(run?.spec?.input);
+
+  const statusFields: ReadOnlyField[] = [
     { id: 'duration', label: 'Duration', value: formatRunDuration(run) ?? '' },
     {
       id: 'execution-timestamp',
       label: 'Execution Timestamp',
-      value: timestampToString(run?.metadata?.creationTimestamp?.seconds, TimeZone.Local) ?? '',
+      value: timestampToString(getExecutionTimestampSeconds(run), TimeZone.Local) ?? '',
     },
   ];
 
-  const configurationFields = [
+  const configurationFields: ReadOnlyField[] = [
     {
       id: 'environment',
       label: 'Environment',
       value: run?.metadata?.labels?.[ENVIRONMENT_LABEL] ?? '',
     },
+    {
+      id: 'parameter-id',
+      label: 'Parameter ID',
+      value: run?.metadata?.labels?.[PARAMETER_ID_LABEL] ?? '',
+    },
   ];
 
-  const fieldColumn = css({
+  const column = css({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.sizing.scale600,
   });
 
-  const renderReadOnlyFields = (fields: { id: string; label: string; value: string }[]) => (
+  const renderReadOnlyFields = (fields: ReadOnlyField[]) => (
     <Form
       onSubmit={() => undefined}
       initialValues={Object.fromEntries(fields.map((field) => [field.id, field.value]))}
     >
-      <div className={fieldColumn}>
+      <div className={column}>
         {fields.map((field) =>
           isLoading ? (
             <Skeleton key={field.id} animation height="48px" width="100%" />
@@ -84,22 +108,56 @@ export function RunInfoPage({ data, isLoading }: { data?: object; isLoading: boo
     </Form>
   );
 
+  const renderJsonBox = (title: string, value: unknown) =>
+    isLoading ? (
+      <Skeleton animation height="200px" width="100%" />
+    ) : (
+      <Box title={title}>
+        <TextEditor
+          value={JSON.stringify(value, null, 2)}
+          language="json"
+          readOnly
+          foldable
+          height="auto"
+        />
+      </Box>
+    );
+
   return (
-    <div className={css({ display: 'flex', flexDirection: 'column', gap: theme.sizing.scale600 })}>
+    <div className={column}>
       <LinksBox title="Useful links" links={links} isLoading={isLoading} />
+
+      {errorMessage && !isLoading && (
+        <section>
+          <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
+            Message
+          </HeadingSmall>
+          <Box>
+            <Form onSubmit={() => undefined} initialValues={{ 'error-message': errorMessage }}>
+              <TextareaField name="error-message" label="Error message" readOnly />
+            </Form>
+          </Box>
+        </section>
+      )}
 
       <section>
         <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
           Key status indicators
         </HeadingSmall>
-        <Box>{renderReadOnlyFields(statusFields)}</Box>
+        <div className={column}>
+          <Box>{renderReadOnlyFields(statusFields)}</Box>
+          {manifestContent !== undefined && renderJsonBox('Content', manifestContent)}
+        </div>
       </section>
 
       <section>
         <HeadingSmall marginTop="0" marginBottom={theme.sizing.scale600}>
           Configuration
         </HeadingSmall>
-        <Box>{renderReadOnlyFields(configurationFields)}</Box>
+        <div className={column}>
+          <Box>{renderReadOnlyFields(configurationFields)}</Box>
+          {input !== undefined && renderJsonBox('Input', input)}
+        </div>
       </section>
     </div>
   );
@@ -110,6 +168,41 @@ function findStepByName(
   name: string
 ): PipelineRunStepInfo | undefined {
   return steps?.find((step) => step.name === name);
+}
+
+/**
+ * The run's input parameters as plain JSON, or undefined when the run has none.
+ * Accepts both a raw protobuf Struct and an already-decoded object.
+ */
+function decodeRunInput(input: unknown): unknown {
+  if (input == null) {
+    return undefined;
+  }
+  const decoded = isStruct(input) ? decodeStruct(input) : input;
+  if (typeof decoded === 'object' && decoded !== null && Object.keys(decoded).length === 0) {
+    return undefined;
+  }
+  return decoded;
+}
+
+/**
+ * Unix seconds the run executed for: the logical time stamped by the trigger workflow
+ * for scheduled runs, else the time the run object was created. Scheduled runs are
+ * usually created moments before their slot, but backfills can be created long after.
+ */
+function getExecutionTimestampSeconds(run: PipelineRunSummary | undefined): string | undefined {
+  const label = run?.metadata?.labels?.[EXECUTION_TIMESTAMP_LABEL];
+  if (label) {
+    if (!isNaN(Number(label))) {
+      return label;
+    }
+    // Older writers recorded the label as an RFC 3339 string.
+    const parsed = Date.parse(label);
+    if (!isNaN(parsed)) {
+      return String(Math.floor(parsed / 1000));
+    }
+  }
+  return run?.metadata?.creationTimestamp?.seconds;
 }
 
 /**

--- a/javascript/packages/core/config/entities/run/shared.ts
+++ b/javascript/packages/core/config/entities/run/shared.ts
@@ -3,6 +3,7 @@ import { interpolate } from '#core/interpolation/interpolate';
 
 import type { Cell } from '#core/components/cell/types';
 import type { TagColor } from '#core/components/tag/types';
+import type { RunWithManifest } from './types';
 
 /**
  * Labels for `PipelineRunStepState`, keyed by the proto enum value.
@@ -139,3 +140,20 @@ export const SHARED_RUN_CELL_CONFIG: Cell[] = [
   RUN_TRIGGERED_BY_COLUMN,
   RUN_STATE_COLUMN,
 ];
+
+/**
+ * Resolves the pipeline configuration a run executes, unpacked from the manifest's
+ * `content` envelope by the rpc layer. Prefers the snapshot captured when the run started
+ * (`status.sourcePipeline`) and falls back to the inline dev-run spec before that snapshot
+ * has been resolved. Shared by the Information and Pipeline Configuration tabs.
+ */
+export function getRunManifestContent(
+  run: RunWithManifest | undefined
+): Record<string, unknown> | undefined {
+  const sourcePipeline = run?.status?.sourcePipeline;
+  const manifest =
+    sourcePipeline?.pipeline?.spec?.manifest ??
+    sourcePipeline?.draftPipeline?.spec?.manifest ??
+    run?.spec?.pipelineSpec?.manifest;
+  return manifest?.content?.value;
+}

--- a/javascript/packages/core/config/entities/run/types.ts
+++ b/javascript/packages/core/config/entities/run/types.ts
@@ -74,11 +74,13 @@ export type PipelineRun = {
   };
   status?: {
     /** Snapshot of the pipeline this run executes, captured when the run starts. */
-    sourcePipeline?: {
-      pipeline?: { spec?: PipelineSnapshotSpec };
-      draftPipeline?: { spec?: PipelineSnapshotSpec };
-    };
+    sourcePipeline?: SourcePipelineSnapshot;
   };
+};
+
+export type SourcePipelineSnapshot = {
+  pipeline?: { spec?: PipelineSnapshotSpec };
+  draftPipeline?: { spec?: PipelineSnapshotSpec };
 };
 
 export type PipelineSnapshotSpec = {
@@ -171,10 +173,14 @@ export type PipelineRunSummary = {
         name?: string;
       };
     };
+    input?: unknown;
+    pipelineSpec?: PipelineSnapshotSpec;
   };
   status?: {
     state?: number;
     steps?: PipelineRunStepInfo[];
+    errorMessage?: string;
+    sourcePipeline?: SourcePipelineSnapshot;
   };
 };
 
@@ -186,4 +192,12 @@ export type ListPipelineRunResponse = {
 
 export type GetPipelineRunResponse = {
   pipelineRun?: PipelineRunSummary;
+};
+
+/** A label/value pair rendered as a read-only text box on the Information tab. */
+export type ReadOnlyField = { id: string; label: string; value: string };
+
+export type RunWithManifest = {
+  spec?: { pipelineSpec?: PipelineSnapshotSpec };
+  status?: { sourcePipeline?: SourcePipelineSnapshot };
 };


### PR DESCRIPTION
**What type of PR is this? (check all applicable)**
- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

<!-- Describe what has changed in this PR -->
**What changed?**
Add info tab for pipeline run detail page

<img width="638" height="588" alt="image" src="https://github.com/user-attachments/assets/b287c9da-6891-465e-bf0c-389cf180d06f" />

### Loading state
<img width="1507" height="910" alt="image" src="https://github.com/user-attachments/assets/a0a05397-784f-4446-9beb-606c809da1df" />


<!-- Tell your future self why have you made these changes -->
**Why?**
Display more pipeline run details 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Does this PR introduce a breaking change? Check all that apply. -->
**Breaking Changes**

- [x] No breaking changes
- [ ] API changes (Go exported symbols or function signatures, Python public functions or classes)
- [ ] Proto changes (enum value renumbering, field number changes, field removal, service removal)
- [ ] Helm changes (new required values, renamed or removed keys, changed value semantics)
- [ ] Config/deployment changes (new required env vars, renamed container args, changed ports or mount paths)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Does this PR introduce a user-facing or API change? Is user document updated? Is the change backward compatible? If so please update in wiki https://github.com/michelangelo-ai/michelangelo/wiki? -->
**Documentation Changes**
N/A